### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/751/765/101751765.geojson
+++ b/data/101/751/765/101751765.geojson
@@ -644,6 +644,9 @@
         "wk:page":"Luxembourg City"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"017fd7de0325896657467d1d4462ca7a",
     "wof:hierarchy":[
         {
@@ -657,7 +660,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566598624,
+    "wof:lastmodified":1582349491,
     "wof:megacity":0,
     "wof:name":"Luxembourg",
     "wof:parent_id":85673875,

--- a/data/101/753/069/101753069.geojson
+++ b/data/101/753/069/101753069.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q985149"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c832e22ba129c11ac0fe7916a46cb40",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598622,
+    "wof:lastmodified":1582349491,
     "wof:name":"Steinsel",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/753/071/101753071.geojson
+++ b/data/101/753/071/101753071.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Walferdange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1659b2dccd66a527ee2635bab645a5a",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598622,
+    "wof:lastmodified":1582349491,
     "wof:name":"Walferdange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/753/075/101753075.geojson
+++ b/data/101/753/075/101753075.geojson
@@ -158,6 +158,9 @@
         "wk:page":"Niederanven"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73bde968eede0f7b1084d798f63d1df2",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598622,
+    "wof:lastmodified":1582349491,
     "wof:name":"Niederanven",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/753/077/101753077.geojson
+++ b/data/101/753/077/101753077.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Mamer"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e94c6183206a9cbd08165dcd8747caa4",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598621,
+    "wof:lastmodified":1582349491,
     "wof:name":"Mamer",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/753/079/101753079.geojson
+++ b/data/101/753/079/101753079.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q986400"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"daa3eff3d25a41f2f26e915b0c89b8e3",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598621,
+    "wof:lastmodified":1582349491,
     "wof:name":"Strassen",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/757/247/101757247.geojson
+++ b/data/101/757/247/101757247.geojson
@@ -58,6 +58,9 @@
         "wd:id":"Q20969263"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4abdb266ca489a10fc3928c33ac04907",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598624,
+    "wof:lastmodified":1582349491,
     "wof:name":"Bertrange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/810/567/101810567.geojson
+++ b/data/101/810/567/101810567.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Heiderscheid"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4e6d722e8a92c11270eeb0e512884a0",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598624,
+    "wof:lastmodified":1582349491,
     "wof:name":"Heiderscheid",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/810/569/101810569.geojson
+++ b/data/101/810/569/101810569.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q985397"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a9f2d71bbf7fc74e2fa00619a0652d1",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598624,
+    "wof:lastmodified":1582349491,
     "wof:name":"Larochette",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/810/571/101810571.geojson
+++ b/data/101/810/571/101810571.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q985477"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"33d55814e132605d6623c02461c3df99",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598624,
+    "wof:lastmodified":1582349491,
     "wof:name":"Kopstal",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/811/715/101811715.geojson
+++ b/data/101/811/715/101811715.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Asselborn"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"855a5052a0075de1f8ca763d1d1e4cd4",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":101811715,
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Asselborn",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/811/723/101811723.geojson
+++ b/data/101/811/723/101811723.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Clervaux"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7d25bc5ec277cfb75bb3af1f3e240da",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101811723,
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Clervaux",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/811/727/101811727.geojson
+++ b/data/101/811/727/101811727.geojson
@@ -129,6 +129,9 @@
         "wd:id":"Q985404"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c80b5276fe68604ad844801bdb07d708",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101811727,
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Wincrange",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/811/731/101811731.geojson
+++ b/data/101/811/731/101811731.geojson
@@ -163,6 +163,9 @@
         "wd:id":"Q741589"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04298b03903aeb8e3ef367a28468fb42",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598622,
+    "wof:lastmodified":1582349491,
     "wof:name":"Wiltz",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/855/101812855.geojson
+++ b/data/101/812/855/101812855.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Bourscheid, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a701ff2f9ef1103009f347ce3df01cf3",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598629,
+    "wof:lastmodified":1582349492,
     "wof:name":"Bourscheid",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/857/101812857.geojson
+++ b/data/101/812/857/101812857.geojson
@@ -133,6 +133,9 @@
         "wd:id":"Q832382"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4a25acbd88d767f278679d37a3ff1a9",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598626,
+    "wof:lastmodified":1582349492,
     "wof:name":"Bettendorf",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/859/101812859.geojson
+++ b/data/101/812/859/101812859.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Diekirch"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a3c8f600b82074c13530f8cbe01d934",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598626,
+    "wof:lastmodified":1582349491,
     "wof:name":"Diekirch",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/861/101812861.geojson
+++ b/data/101/812/861/101812861.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Niederfeulen"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4db913fbbf69477f639a682ed9348b35",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598626,
+    "wof:lastmodified":1582349492,
     "wof:name":"Niederfeulen",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/863/101812863.geojson
+++ b/data/101/812/863/101812863.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Beaufort, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9f1889eba7f1c58171b248526f511088",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598629,
+    "wof:lastmodified":1582349492,
     "wof:name":"Beaufort",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/812/865/101812865.geojson
+++ b/data/101/812/865/101812865.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Mertzig"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e391203b91664c55216df8bcfae915d",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598628,
+    "wof:lastmodified":1582349492,
     "wof:name":"Mertzig",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/867/101812867.geojson
+++ b/data/101/812/867/101812867.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Rambrouch"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"15b29f08bfafd71bd5eebb9291c5acf8",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598627,
+    "wof:lastmodified":1582349492,
     "wof:name":"Rambrouch",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/871/101812871.geojson
+++ b/data/101/812/871/101812871.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Berdorf"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27370c770062ab88bb857cfb6faf006f",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598628,
+    "wof:lastmodified":1582349492,
     "wof:name":"Berdorf",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/812/877/101812877.geojson
+++ b/data/101/812/877/101812877.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q866692"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"66434ae400a7965b54ec6f58d4ee04ad",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598628,
+    "wof:lastmodified":1582349492,
     "wof:name":"Bissen",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/879/101812879.geojson
+++ b/data/101/812/879/101812879.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q660217"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d14b3a7483049ff90579a11e29d6676",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598628,
+    "wof:lastmodified":1582349492,
     "wof:name":"Consdorf",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/812/881/101812881.geojson
+++ b/data/101/812/881/101812881.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q985333"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b225cb2b4732ae999f5ab7b91ca5a4c1",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598625,
+    "wof:lastmodified":1582349491,
     "wof:name":"Useldange",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/812/883/101812883.geojson
+++ b/data/101/812/883/101812883.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Mersch"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9aaa70e23204243ba4e145b5a9b53fbc",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1568063410,
+    "wof:lastmodified":1582349492,
     "wof:name":"Mersch",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/885/101812885.geojson
+++ b/data/101/812/885/101812885.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Lintgen"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e6ecfbbf993cca11008167f141a96b99",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598628,
+    "wof:lastmodified":1582349492,
     "wof:name":"Lintgen",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/889/101812889.geojson
+++ b/data/101/812/889/101812889.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q1017404"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e5aa4f7001da8180d3c5b4834857969c",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598625,
+    "wof:lastmodified":1582349491,
     "wof:name":"Junglinster",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/812/891/101812891.geojson
+++ b/data/101/812/891/101812891.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Manternach"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e42bc0599ad999309b9ab13b577df01",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598629,
+    "wof:lastmodified":1582349492,
     "wof:name":"Manternach",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/812/893/101812893.geojson
+++ b/data/101/812/893/101812893.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Koerich"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35908b78f17a2ec6af1d7817f2bcc3ce",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598627,
+    "wof:lastmodified":1582349492,
     "wof:name":"Koerich",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/895/101812895.geojson
+++ b/data/101/812/895/101812895.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q432495"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec8396c081e9414f21499b20adf0d150",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598626,
+    "wof:lastmodified":1582349491,
     "wof:name":"Kehlen",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/899/101812899.geojson
+++ b/data/101/812/899/101812899.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q956489"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32f456ad131758f958295f22e8c4abe6",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598629,
+    "wof:lastmodified":1582349492,
     "wof:name":"Schuttrange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/901/101812901.geojson
+++ b/data/101/812/901/101812901.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Garnich"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e237e0ca3395ec2ee4f8d7992fb2fc43",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598625,
+    "wof:lastmodified":1582349491,
     "wof:name":"Garnich",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/903/101812903.geojson
+++ b/data/101/812/903/101812903.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q21053530"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3079d8fec7dcfe19388fecc6f30d57c",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598627,
+    "wof:lastmodified":1582349492,
     "wof:name":"Clemency",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/907/101812907.geojson
+++ b/data/101/812/907/101812907.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Dippach"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52f302e0dc759149112f17cb4a37cebf",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598625,
+    "wof:lastmodified":1582349491,
     "wof:name":"Dippach",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/909/101812909.geojson
+++ b/data/101/812/909/101812909.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Contern"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b43d31b256aa2968fdd6fb1a3575765",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598625,
+    "wof:lastmodified":1582349491,
     "wof:name":"Contern",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/911/101812911.geojson
+++ b/data/101/812/911/101812911.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Leudelange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b1a8eae371dbac0932482ae308fbcb49",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":101812911,
-    "wof:lastmodified":1566598629,
+    "wof:lastmodified":1582349492,
     "wof:name":"Leudelange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/913/101812913.geojson
+++ b/data/101/812/913/101812913.geojson
@@ -133,6 +133,9 @@
         "wd:id":"Q986412"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f7ecfc662ecf632cc3608e75e8881b6",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598627,
+    "wof:lastmodified":1582349492,
     "wof:name":"Dalheim",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/812/915/101812915.geojson
+++ b/data/101/812/915/101812915.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Mondercange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"626806ad7d685d7970b6b40dd675042f",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":101812915,
-    "wof:lastmodified":1566598627,
+    "wof:lastmodified":1582349492,
     "wof:name":"Mondercange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/917/101812917.geojson
+++ b/data/101/812/917/101812917.geojson
@@ -141,6 +141,9 @@
         "wd:id":"Q832342"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35f213dd4106eaf21a6df43885a3c6cc",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101812917,
-    "wof:lastmodified":1566598630,
+    "wof:lastmodified":1582349492,
     "wof:name":"Bettembourg",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/919/101812919.geojson
+++ b/data/101/812/919/101812919.geojson
@@ -120,6 +120,9 @@
         "wd:id":"Q1017402"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"439067ac540890a2c902579617b1239e",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101812919,
-    "wof:lastmodified":1566598630,
+    "wof:lastmodified":1582349492,
     "wof:name":"Frisange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/812/921/101812921.geojson
+++ b/data/101/812/921/101812921.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Mondorf-les-Bains"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ce29ef3880f39b717723638323117ed9",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598630,
+    "wof:lastmodified":1582349492,
     "wof:name":"Mondorf-les-Bains",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/839/151/101839151.geojson
+++ b/data/101/839/151/101839151.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Erpeldange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23c68ed66e6af96d68a3403d2439a671",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Erpeldange",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/839/153/101839153.geojson
+++ b/data/101/839/153/101839153.geojson
@@ -211,6 +211,9 @@
         "wk:page":"Ettelbruck"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44391592c56360479dc01e918900ea85",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598632,
+    "wof:lastmodified":1582349493,
     "wof:name":"Ettelbr\u00fcck",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/839/799/101839799.geojson
+++ b/data/101/839/799/101839799.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q985387"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"259130fe864c26aededc7c87315e4de1",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Mertert",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/839/801/101839801.geojson
+++ b/data/101/839/801/101839801.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Grevenmacher"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b063bbb0f7572e91b3f0637afc9ef771",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598633,
+    "wof:lastmodified":1582349493,
     "wof:name":"Grevenmacher",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/839/803/101839803.geojson
+++ b/data/101/839/803/101839803.geojson
@@ -246,6 +246,9 @@
         "wk:page":"Esch-sur-Alzette"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b149c82df1ca2d00e223db82d1b3ef7e",
     "wof:hierarchy":[
         {
@@ -259,7 +262,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566598632,
+    "wof:lastmodified":1582349492,
     "wof:name":"Esch-sur-Alzette",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/805/101839805.geojson
+++ b/data/101/839/805/101839805.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Kayl"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e79fe851716c69ed1d4654d54e87dfb6",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101839805,
-    "wof:lastmodified":1566598632,
+    "wof:lastmodified":1582349492,
     "wof:name":"Kayl",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/807/101839807.geojson
+++ b/data/101/839/807/101839807.geojson
@@ -177,6 +177,9 @@
         "wd:id":"Q16014"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16b8886d0f9c9df97e704cd7ce9d6aa2",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":101839807,
-    "wof:lastmodified":1566598633,
+    "wof:lastmodified":1582349493,
     "wof:name":"Dudelange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/809/101839809.geojson
+++ b/data/101/839/809/101839809.geojson
@@ -178,6 +178,9 @@
         "wk:page":"Rumelange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a939ff9fe337c330894c591f5f29dc52",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":101839809,
-    "wof:lastmodified":1566598633,
+    "wof:lastmodified":1582349493,
     "wof:name":"Rumelange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/811/101839811.geojson
+++ b/data/101/839/811/101839811.geojson
@@ -137,6 +137,9 @@
         "wd:id":"Q20969248"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9cc5aa3d4bc463ce8350d847a94a2259",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Bascharage",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/813/101839813.geojson
+++ b/data/101/839/813/101839813.geojson
@@ -147,6 +147,9 @@
         "wd:id":"Q602441"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6fb339358c3c50d2d754dce137e20004",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":101839813,
-    "wof:lastmodified":1566598633,
+    "wof:lastmodified":1582349493,
     "wof:name":"P\u00e9tange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/817/101839817.geojson
+++ b/data/101/839/817/101839817.geojson
@@ -282,6 +282,9 @@
         "wd:id":"Q4844168"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b1ef9057f83d3367001dbe76b705558",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         }
     ],
     "wof:id":101839817,
-    "wof:lastmodified":1566598632,
+    "wof:lastmodified":1582349492,
     "wof:name":"Differdange",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/839/819/101839819.geojson
+++ b/data/101/839/819/101839819.geojson
@@ -135,6 +135,9 @@
         "qs_pg:id":487828
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8a035e789d8f72a702cfbe446adf31c",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":101839819,
-    "wof:lastmodified":1566598632,
+    "wof:lastmodified":1582349492,
     "wof:name":"Nittel",
     "wof:parent_id":102063545,
     "wof:placetype":"locality",

--- a/data/101/845/555/101845555.geojson
+++ b/data/101/845/555/101845555.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Hosingen"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e47b32ff9a4148d9c838ed8114d311f",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101845555,
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Hosingen",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/845/561/101845561.geojson
+++ b/data/101/845/561/101845561.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Redange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c165f845598fb46e54cd93f88fcf644",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Redange",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/845/563/101845563.geojson
+++ b/data/101/845/563/101845563.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q813727"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99404e067ee5f8abb7d5925451489968",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Beckerich",
     "wof:parent_id":85673865,
     "wof:placetype":"locality",

--- a/data/101/845/565/101845565.geojson
+++ b/data/101/845/565/101845565.geojson
@@ -136,6 +136,9 @@
         "wd:id":"Q958682"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"725f79931adca071c779f1a6a2dcc761",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Hobscheid",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/845/567/101845567.geojson
+++ b/data/101/845/567/101845567.geojson
@@ -115,6 +115,9 @@
         "wd:id":"Q985390"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d09a8fb5edf56e88cdc313d6bb47b1ae",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598623,
+    "wof:lastmodified":1582349491,
     "wof:name":"Weiler-la-Tour",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/853/467/101853467.geojson
+++ b/data/101/853/467/101853467.geojson
@@ -120,6 +120,10 @@
         "wd:id":"Q1017407"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c33f29faf4a58aca49e887b57d32ea00",
     "wof:hierarchy":[
         {
@@ -133,7 +137,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598630,
+    "wof:lastmodified":1582349492,
     "wof:name":"Waldbredimus",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/854/567/101854567.geojson
+++ b/data/101/854/567/101854567.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Berg, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c6b4cdcb1236c9bc3f597d6d1c070a6",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Berg",
     "wof:parent_id":85673875,
     "wof:placetype":"locality",

--- a/data/101/854/569/101854569.geojson
+++ b/data/101/854/569/101854569.geojson
@@ -132,6 +132,10 @@
         "wd:id":"Q850734"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"62107dcaf0a3ce0a00dc87b8eb22d472",
     "wof:hierarchy":[
         {
@@ -145,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Betzdorf",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/854/571/101854571.geojson
+++ b/data/101/854/571/101854571.geojson
@@ -120,6 +120,10 @@
         "wd:id":"Q1017425"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f634a7f03dd3fd4c0cbdb5a830a84de",
     "wof:hierarchy":[
         {
@@ -133,7 +137,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Flaxweiler",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/101/854/573/101854573.geojson
+++ b/data/101/854/573/101854573.geojson
@@ -126,6 +126,10 @@
         "wd:id":"Q1017410"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"931114f7179fb85662c2c353811f0e7f",
     "wof:hierarchy":[
         {
@@ -139,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598631,
+    "wof:lastmodified":1582349492,
     "wof:name":"Lenningen",
     "wof:parent_id":85673869,
     "wof:placetype":"locality",

--- a/data/856/332/75/85633275.geojson
+++ b/data/856/332/75/85633275.geojson
@@ -1162,6 +1162,10 @@
     },
     "wof:country":"LU",
     "wof:country_alpha3":"LUX",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"44a2eaf3f37651849f0e98484cad337b",
     "wof:hierarchy":[
         {
@@ -1180,7 +1184,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1566598605,
+    "wof:lastmodified":1582349490,
     "wof:name":"Luxembourg",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/858/020/39/85802039.geojson
+++ b/data/858/020/39/85802039.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Alzingen"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b6c6a74c2c18b9dcb8d774f54f2bf8f",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598607,
+    "wof:lastmodified":1582349490,
     "wof:name":"Alzingen",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/43/85802043.geojson
+++ b/data/858/020/43/85802043.geojson
@@ -108,6 +108,10 @@
         "wk:page":"Beggen"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3f95f036a3caf4a360596fdd83ceba8",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598607,
+    "wof:lastmodified":1582349490,
     "wof:name":"Beggen",
     "wof:parent_id":101753071,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/47/85802047.geojson
+++ b/data/858/020/47/85802047.geojson
@@ -121,6 +121,11 @@
         "wk:page":"Bonnevoie"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"17921c2730632920475e3ad9a7bfe31e",
     "wof:hierarchy":[
         {
@@ -135,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598608,
+    "wof:lastmodified":1582349490,
     "wof:name":"Bonnevoie",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/53/85802053.geojson
+++ b/data/858/020/53/85802053.geojson
@@ -156,6 +156,10 @@
         "wd:id":"Q1821038"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"58adccf2b16a5285de76c54cc6a3c648",
     "wof:hierarchy":[
         {
@@ -170,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598607,
+    "wof:lastmodified":1582349490,
     "wof:name":"Cents",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/57/85802057.geojson
+++ b/data/858/020/57/85802057.geojson
@@ -103,6 +103,11 @@
         "wk:page":"Cessange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"a2f19a744f1d84644cf22c6950afb860",
     "wof:hierarchy":[
         {
@@ -117,7 +122,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598606,
+    "wof:lastmodified":1582349490,
     "wof:name":"Cessange",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/61/85802061.geojson
+++ b/data/858/020/61/85802061.geojson
@@ -101,6 +101,11 @@
         "wk:page":"Clausen, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"78134d40d6a23ef29242b6d219b6a6a0",
     "wof:hierarchy":[
         {
@@ -115,7 +120,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598606,
+    "wof:lastmodified":1582349490,
     "wof:name":"Clausen",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/65/85802065.geojson
+++ b/data/858/020/65/85802065.geojson
@@ -107,6 +107,11 @@
         "wk:page":"Dommeldange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"628fffbea6d65039f98f35d4142a2f87",
     "wof:hierarchy":[
         {
@@ -121,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598607,
+    "wof:lastmodified":1582349490,
     "wof:name":"Dommeldange",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/71/85802071.geojson
+++ b/data/858/020/71/85802071.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Fentange"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"761733af2bcba4eb95a0dec9b119471d",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598608,
+    "wof:lastmodified":1582349490,
     "wof:name":"Fentange",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/73/85802073.geojson
+++ b/data/858/020/73/85802073.geojson
@@ -107,6 +107,11 @@
         "wk:page":"Gasperich"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"616b8a0f3ef3e81d3acefba4184d0d34",
     "wof:hierarchy":[
         {
@@ -121,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598606,
+    "wof:lastmodified":1582349490,
     "wof:name":"Gasperich",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/77/85802077.geojson
+++ b/data/858/020/77/85802077.geojson
@@ -106,6 +106,11 @@
         "wk:page":"Hamm, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"77bf35719a1de8f2ac7fddb8abc1eaf4",
     "wof:hierarchy":[
         {
@@ -120,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598608,
+    "wof:lastmodified":1582349490,
     "wof:name":"Hamm",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/81/85802081.geojson
+++ b/data/858/020/81/85802081.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Howald"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d89b60a29d8ea086f3b34ace3062e014",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598606,
+    "wof:lastmodified":1582349490,
     "wof:name":"Howald",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/87/85802087.geojson
+++ b/data/858/020/87/85802087.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Itzig, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7738407fd27e8bfafca5c386d8ed89b4",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598606,
+    "wof:lastmodified":1582349490,
     "wof:name":"Itzig",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/91/85802091.geojson
+++ b/data/858/020/91/85802091.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":36726
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"079ffcc9f96161d3a3b0c90c3658ca38",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598607,
+    "wof:lastmodified":1582349490,
     "wof:name":"Itzigerste",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/93/85802093.geojson
+++ b/data/858/020/93/85802093.geojson
@@ -129,6 +129,11 @@
         "wk:page":"Kirchberg, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf3e699b3368188a5748ef34c65d6157",
     "wof:hierarchy":[
         {
@@ -143,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598606,
+    "wof:lastmodified":1582349490,
     "wof:name":"Kirchberg",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/97/85802097.geojson
+++ b/data/858/020/97/85802097.geojson
@@ -105,6 +105,11 @@
         "wk:page":"Merl, Luxembourg"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf4cdb511f2a4cf50b3cab2161097f7a",
     "wof:hierarchy":[
         {
@@ -119,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598607,
+    "wof:lastmodified":1582349490,
     "wof:name":"Merl",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/01/85802101.geojson
+++ b/data/858/021/01/85802101.geojson
@@ -104,6 +104,10 @@
         "wk:page":"Weimerskirch"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1d94bc115092fa37c05d945dec94aeb",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598608,
+    "wof:lastmodified":1582349490,
     "wof:name":"Neimersk",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/07/85802107.geojson
+++ b/data/858/021/07/85802107.geojson
@@ -96,6 +96,11 @@
         "wk:page":"Rollingergrund"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9ae34a7be18c0cc872b642ddf944c4d",
     "wof:hierarchy":[
         {
@@ -110,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598608,
+    "wof:lastmodified":1582349490,
     "wof:name":"Rollingergrund",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/13/85802113.geojson
+++ b/data/858/021/13/85802113.geojson
@@ -106,6 +106,11 @@
         "wk:page":"Weimerskirch"
     },
     "wof:country":"LU",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"284beb59519a3e505ac3be3cd94e16b5",
     "wof:hierarchy":[
         {
@@ -120,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598608,
+    "wof:lastmodified":1582349490,
     "wof:name":"Waymersk",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.