### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/101/751/765/101751765.geojson
+++ b/data/101/751/765/101751765.geojson
@@ -21,6 +21,9 @@
     "name:afr_x_preferred":[
         "Luxemburg"
     ],
+    "name:aka_x_preferred":[
+        "Luxembourg"
+    ],
     "name:als_x_preferred":[
         "Luxemburg"
     ],
@@ -36,11 +39,26 @@
     "name:arg_x_preferred":[
         "Luxemburgo"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0648\u0643\u0633\u0645\u0628\u0648\u0631\u06ad"
+    ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0643\u0633\u0645\u0628\u0648\u0631\u062c"
+    ],
     "name:ast_x_preferred":[
         "Luxemburgu"
     ],
+    "name:ava_x_preferred":[
+        "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
+    ],
+    "name:avk_x_preferred":[
+        "Luxemburg"
+    ],
     "name:aze_x_preferred":[
         "L\u00fcksemburq"
+    ],
+    "name:ban_x_preferred":[
+        "Luksemburg"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
@@ -51,6 +69,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09b2\u09c1\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09c1\u09b0\u09cd\u0997"
+    ],
+    "name:ben_x_variant":[
+        "\u09b2\u09c1\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09c1\u09b0\u09cd\u0997 \u09b6\u09b9\u09b0"
     ],
     "name:bod_x_preferred":[
         "\u0f63\u0f74\u0f0b\u0f66\u0f7a\u0f58\u0f0b\u0f56\u0f60\u0f74\u0f62\u0f42"
@@ -115,7 +136,6 @@
     ],
     "name:eng_x_variant":[
         "LUX",
-        "Luxembourg",
         "Luxembourg City"
     ],
     "name:epo_x_preferred":[
@@ -154,6 +174,9 @@
     "name:fry_x_preferred":[
         "L\u00faksemboarch"
     ],
+    "name:fur_x_preferred":[
+        "Lussemburc"
+    ],
     "name:gla_x_preferred":[
         "Lucsamburg"
     ],
@@ -177,6 +200,9 @@
     ],
     "name:hat_x_preferred":[
         "Liksanbou"
+    ],
+    "name:hau_x_preferred":[
+        "Birnin Luxembourg"
     ],
     "name:hbs_x_preferred":[
         "Luxembourg"
@@ -287,11 +313,17 @@
     "name:mar_x_preferred":[
         "\u0932\u0915\u094d\u091d\u0947\u0902\u092c\u0930\u094d\u0917"
     ],
+    "name:mdf_x_preferred":[
+        "\u041b\u044e\u043a\u0441\u044d\u043c\u0431\u0443\u0440\u0433"
+    ],
     "name:mkd_x_preferred":[
         "\u041b\u0443\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
     ],
     "name:mlt_x_preferred":[
         "Lussemburgu"
+    ],
+    "name:mlt_x_variant":[
+        "Belt tal-Lussemburgu"
     ],
     "name:mon_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
@@ -304,6 +336,9 @@
     ],
     "name:myv_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433 \u043e\u0448"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u06af"
     ],
     "name:nah_x_preferred":[
         "\u0100ltep\u0113tl Luxemburgo"
@@ -383,6 +418,12 @@
     "name:sme_x_preferred":[
         "Luxemburg"
     ],
+    "name:smn_x_preferred":[
+        "Luxemburg"
+    ],
+    "name:sms_x_preferred":[
+        "Luxemburgg"
+    ],
     "name:sna_x_preferred":[
         "Luxembourg City"
     ],
@@ -449,6 +490,9 @@
     "name:ukr_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
     ],
+    "name:ukr_x_variant":[
+        "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0491"
+    ],
     "name:und_x_variant":[
         "Letzeburg"
     ],
@@ -473,6 +517,9 @@
     "name:vie_x_preferred":[
         "Luxembourg"
     ],
+    "name:vls_x_preferred":[
+        "Luxemburg"
+    ],
     "name:vol_x_preferred":[
         "Luxemburg"
     ],
@@ -487,6 +534,9 @@
     ],
     "name:wol_x_preferred":[
         "Luksambuur"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5362\u68ee\u5821"
     ],
     "name:xmf_x_preferred":[
         "\u10da\u10e3\u10e5\u10e1\u10d4\u10db\u10d1\u10e3\u10e0\u10d2\u10d8"
@@ -684,7 +734,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1636501778,
+    "wof:lastmodified":1690938750,
     "wof:megacity":0,
     "wof:name":"Luxembourg",
     "wof:parent_id":1125286201,

--- a/data/101/753/069/101753069.geojson
+++ b/data/101/753/069/101753069.geojson
@@ -30,6 +30,9 @@
     "name:ceb_x_preferred":[
         "Steinsel"
     ],
+    "name:ces_x_preferred":[
+        "Steinsel"
+    ],
     "name:dan_x_preferred":[
         "Steinsel"
     ],
@@ -48,11 +51,20 @@
     "name:gsw_x_preferred":[
         "Steesel"
     ],
+    "name:heb_x_preferred":[
+        "\u05e9\u05d8\u05d9\u05d9\u05e0\u05d6\u05dc"
+    ],
     "name:hun_x_preferred":[
         "Steinsel"
     ],
     "name:ita_x_preferred":[
         "Steinsel"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b9\u30bf\u30f3\u30bb\u30eb"
+    ],
+    "name:lit_x_preferred":[
+        "\u0160teinselis"
     ],
     "name:ltz_x_preferred":[
         "Gemeng Steesel"
@@ -90,8 +102,14 @@
     "name:swe_x_preferred":[
         "Steinsel"
     ],
+    "name:tur_x_preferred":[
+        "Steinsel"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0442\u0430\u0439\u043d\u0441\u0435\u043b\u044c"
+    ],
+    "name:zho_x_preferred":[
+        "\u65bd\u6cf0\u56e0\u745f\u5c14"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -155,7 +173,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732096,
+    "wof:lastmodified":1690938746,
     "wof:name":"Steinsel",
     "wof:parent_id":1125305385,
     "wof:placetype":"locality",

--- a/data/101/753/071/101753071.geojson
+++ b/data/101/753/071/101753071.geojson
@@ -33,6 +33,9 @@
     "name:ceb_x_preferred":[
         "Walferdange"
     ],
+    "name:ces_x_preferred":[
+        "Walferdange"
+    ],
     "name:dan_x_preferred":[
         "Walferdange"
     ],
@@ -54,17 +57,26 @@
     "name:gsw_x_preferred":[
         "Walfer"
     ],
+    "name:hin_x_preferred":[
+        "\u0935\u093e\u0932\u092b\u0947\u0930\u0921\u0947\u0902\u091c"
+    ],
     "name:hun_x_preferred":[
         "Walferdange"
     ],
     "name:ita_x_preferred":[
         "Walferdange"
     ],
+    "name:lit_x_preferred":[
+        "Valferdan\u017eas"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Walfer"
     ],
     "name:ltz_x_variant":[
         "Walfer"
+    ],
+    "name:mlt_x_preferred":[
+        "Walferdange"
     ],
     "name:msa_x_preferred":[
         "Walferdange"
@@ -102,11 +114,20 @@
     "name:swe_x_preferred":[
         "Walferdange"
     ],
+    "name:tur_x_preferred":[
+        "Walferdange"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u043b\u044c\u0444\u0435\u0440\u0434\u0430\u043d\u0436"
     ],
+    "name:urd_x_preferred":[
+        "\u0648\u0627\u0644\u0641\u0631\u0688\u06cc\u0646\u062c"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Walferdange"
+    ],
+    "name:zho_x_preferred":[
+        "\u74e6\u5c14\u5f17\u5f53\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -175,7 +196,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732097,
+    "wof:lastmodified":1690938745,
     "wof:name":"Walferdange",
     "wof:parent_id":1125355305,
     "wof:placetype":"locality",

--- a/data/101/753/075/101753075.geojson
+++ b/data/101/753/075/101753075.geojson
@@ -63,14 +63,23 @@
     "name:ita_x_preferred":[
         "Niederanven"
     ],
+    "name:jpn_x_preferred":[
+        "\u30cb\u30fc\u30c7\u30e9\u30f3\u30f4\u30a7\u30f3"
+    ],
     "name:kor_x_preferred":[
         "\ub2c8\ub370\ub780\ud39c"
+    ],
+    "name:lit_x_preferred":[
+        "Nyderanvenas"
     ],
     "name:ltz_x_preferred":[
         "Gemeng Nidderaanwen"
     ],
     "name:ltz_x_variant":[
         "Nidderaanwen"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041d\u0438\u0434\u044d\u0440\u0430\u043d\u0432\u044d\u043d"
     ],
     "name:msa_x_preferred":[
         "Niederanven"
@@ -116,6 +125,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Niederanven"
+    ],
+    "name:zho_x_preferred":[
+        "\u4e0b\u5b89\u6587"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -186,7 +198,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732098,
+    "wof:lastmodified":1690938746,
     "wof:name":"Niederanven",
     "wof:parent_id":1125410759,
     "wof:placetype":"locality",

--- a/data/101/753/077/101753077.geojson
+++ b/data/101/753/077/101753077.geojson
@@ -21,6 +21,9 @@
     "name:als_x_preferred":[
         "Mamer"
     ],
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u0645\u0631"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u0430\u043c\u0435\u0440"
     ],
@@ -60,6 +63,9 @@
     "name:ita_x_preferred":[
         "Mamer"
     ],
+    "name:lim_x_preferred":[
+        "Mamer"
+    ],
     "name:lit_x_preferred":[
         "Mameris"
     ],
@@ -93,6 +99,9 @@
     "name:por_x_preferred":[
         "Mamer"
     ],
+    "name:pus_x_preferred":[
+        "\u0645\u0627\u0645\u06d0\u0631"
+    ],
     "name:ron_x_preferred":[
         "Mamer"
     ],
@@ -112,6 +121,9 @@
         "Mamer"
     ],
     "name:swe_x_preferred":[
+        "Mamer"
+    ],
+    "name:tur_x_preferred":[
         "Mamer"
     ],
     "name:ukr_x_preferred":[
@@ -191,7 +203,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732100,
+    "wof:lastmodified":1690938745,
     "wof:name":"Mamer",
     "wof:parent_id":1125305791,
     "wof:placetype":"locality",

--- a/data/101/753/079/101753079.geojson
+++ b/data/101/753/079/101753079.geojson
@@ -93,8 +93,14 @@
     "name:swe_x_preferred":[
         "Strassen"
     ],
+    "name:tur_x_preferred":[
+        "Strassen"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0442\u0440\u0430\u0441\u0441\u0435\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u65bd\u7279\u62c9\u68ee"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -158,7 +164,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1642551746,
+    "wof:lastmodified":1690938745,
     "wof:name":"Strassen",
     "wof:parent_id":1125320855,
     "wof:placetype":"locality",

--- a/data/101/810/569/101810569.geojson
+++ b/data/101/810/569/101810569.geojson
@@ -48,8 +48,14 @@
     "name:ita_x_preferred":[
         "Larochette"
     ],
+    "name:kor_x_preferred":[
+        "\ub77c\ub85c\uc170\ud2b8"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Fiels"
+    ],
+    "name:ltz_x_variant":[
+        "Fiels"
     ],
     "name:msa_x_preferred":[
         "Larochette"
@@ -81,8 +87,14 @@
     "name:swe_x_preferred":[
         "Larochette"
     ],
+    "name:tur_x_preferred":[
+        "Larochette"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0430\u0440\u043e\u0448\u0435\u0442\u0442"
+    ],
+    "name:zho_x_preferred":[
+        "\u62c9\u7f57\u8c22\u7279"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -146,7 +158,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732104,
+    "wof:lastmodified":1690938750,
     "wof:name":"Larochette",
     "wof:parent_id":1125402083,
     "wof:placetype":"locality",

--- a/data/101/810/571/101810571.geojson
+++ b/data/101/810/571/101810571.geojson
@@ -18,6 +18,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0648\u0628\u0633\u062a\u0627\u0644"
+    ],
     "name:bel_x_preferred":[
         "\u041a\u043e\u043f\u0441\u0442\u0430\u043b\u044c"
     ],
@@ -48,8 +51,14 @@
     "name:ita_x_preferred":[
         "Kopstal"
     ],
+    "name:lim_x_preferred":[
+        "Kopstal"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Koplescht"
+    ],
+    "name:ltz_x_variant":[
+        "Koplescht"
     ],
     "name:msa_x_preferred":[
         "Kopstal"
@@ -78,11 +87,20 @@
     "name:slk_x_preferred":[
         "Kopstal"
     ],
+    "name:spa_x_preferred":[
+        "Kopstal"
+    ],
     "name:swe_x_preferred":[
+        "Kopstal"
+    ],
+    "name:tur_x_preferred":[
         "Kopstal"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043f\u0441\u0442\u0430\u043b\u044c"
+    ],
+    "name:zho_x_preferred":[
+        "\u79d1\u666e\u65af\u5854\u5c14"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -146,7 +164,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1642551767,
+    "wof:lastmodified":1690938750,
     "wof:name":"Kopstal",
     "wof:parent_id":1125286175,
     "wof:placetype":"locality",

--- a/data/101/811/723/101811723.geojson
+++ b/data/101/811/723/101811723.geojson
@@ -115,6 +115,12 @@
     "name:swe_x_preferred":[
         "Clervaux"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e04\u0e25\u0e35\u0e22\u0e23\u0e4c\u0e1f"
+    ],
+    "name:tur_x_preferred":[
+        "Clervaux"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043b\u0435\u0440\u0432\u043e"
     ],
@@ -190,7 +196,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732107,
+    "wof:lastmodified":1690938747,
     "wof:name":"Clervaux",
     "wof:parent_id":1125411213,
     "wof:placetype":"locality",

--- a/data/101/811/727/101811727.geojson
+++ b/data/101/811/727/101811727.geojson
@@ -57,6 +57,9 @@
     "name:ltz_x_preferred":[
         "Gemeng W\u00ebntger"
     ],
+    "name:ltz_x_variant":[
+        "W\u00ebntger"
+    ],
     "name:msa_x_preferred":[
         "Wincrange"
     ],
@@ -90,11 +93,17 @@
     "name:swe_x_preferred":[
         "Wincrange"
     ],
+    "name:tur_x_preferred":[
+        "Wincrange"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0456\u043d\u043a\u0440\u0430\u043d\u0436"
     ],
     "name:und_x_variant":[
         "Wenerange"
+    ],
+    "name:zho_x_preferred":[
+        "\u4e07\u514b\u6717\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -154,7 +163,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732109,
+    "wof:lastmodified":1690938747,
     "wof:name":"Wincrange",
     "wof:parent_id":1745980853,
     "wof:placetype":"locality",

--- a/data/101/811/731/101811731.geojson
+++ b/data/101/811/731/101811731.geojson
@@ -46,8 +46,10 @@
         "Wiltz"
     ],
     "name:eng_x_variant":[
-        "Wiltz",
         "Wilz"
+    ],
+    "name:epo_x_preferred":[
+        "Wiltz"
     ],
     "name:eus_x_preferred":[
         "Wiltz"
@@ -103,6 +105,9 @@
     "name:por_x_preferred":[
         "Wiltz"
     ],
+    "name:pus_x_preferred":[
+        "\u0648\u06cc\u0644\u062a\u0632"
+    ],
     "name:ron_x_preferred":[
         "Wiltz"
     ],
@@ -121,11 +126,20 @@
     "name:swe_x_preferred":[
         "Wiltz"
     ],
+    "name:tha_x_preferred":[
+        "\u0e42\u0e27\u0e25\u0e15\u0e2a\u0e4c"
+    ],
+    "name:tur_x_preferred":[
+        "Wiltz"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0456\u043b\u044c\u0446"
     ],
     "name:vol_x_preferred":[
         "Wiltz"
+    ],
+    "name:wln_x_preferred":[
+        "Wilse"
     ],
     "name:zho_x_preferred":[
         "\u7dad\u723e\u8328"
@@ -192,7 +206,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732110,
+    "wof:lastmodified":1690938746,
     "wof:name":"Wiltz",
     "wof:parent_id":1125390667,
     "wof:placetype":"locality",

--- a/data/101/812/855/101812855.geojson
+++ b/data/101/812/855/101812855.geojson
@@ -57,11 +57,17 @@
     "name:ita_x_preferred":[
         "Bourscheid"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d6\u30fc\u30eb\u30b7\u30e3\u30a4\u30c8"
+    ],
     "name:lim_x_preferred":[
         "Bourscheid"
     ],
     "name:ltz_x_preferred":[
         "Gemeng Buerschent"
+    ],
+    "name:ltz_x_variant":[
+        "Buerschent"
     ],
     "name:msa_x_preferred":[
         "Bourscheid"
@@ -99,6 +105,9 @@
     "name:swe_x_preferred":[
         "Bourscheid"
     ],
+    "name:tur_x_preferred":[
+        "Bourscheid"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0443\u0440\u0448\u0430\u0439\u0434"
     ],
@@ -107,6 +116,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u5c14\u65af\u8c22"
+    ],
+    "name:zho_x_variant":[
+        "\u5e03\u5c14\u6c99\u4f0a\u5fb7"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -176,7 +188,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732112,
+    "wof:lastmodified":1690938758,
     "wof:name":"Bourscheid",
     "wof:parent_id":1125333097,
     "wof:placetype":"locality",

--- a/data/101/812/857/101812857.geojson
+++ b/data/101/812/857/101812857.geojson
@@ -69,6 +69,9 @@
     "name:nds_x_preferred":[
         "Gemeen Bettendorf"
     ],
+    "name:nds_x_variant":[
+        "Bettendorf"
+    ],
     "name:nld_x_preferred":[
         "Bettendorf"
     ],
@@ -91,6 +94,9 @@
         "Bettendorf"
     ],
     "name:swe_x_preferred":[
+        "Bettendorf"
+    ],
+    "name:tur_x_preferred":[
         "Bettendorf"
     ],
     "name:ukr_x_preferred":[
@@ -161,7 +167,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732114,
+    "wof:lastmodified":1690938754,
     "wof:name":"Bettendorf",
     "wof:parent_id":1125351511,
     "wof:placetype":"locality",

--- a/data/101/812/859/101812859.geojson
+++ b/data/101/812/859/101812859.geojson
@@ -39,6 +39,9 @@
     "name:ceb_x_preferred":[
         "District de Diekirch"
     ],
+    "name:ces_x_preferred":[
+        "Diekirch"
+    ],
     "name:dan_x_preferred":[
         "Diekirch"
     ],
@@ -49,6 +52,9 @@
         "Diekirch"
     ],
     "name:eng_x_preferred":[
+        "Diekirch"
+    ],
+    "name:epo_x_preferred":[
         "Diekirch"
     ],
     "name:eus_x_preferred":[
@@ -153,11 +159,17 @@
     "name:swe_x_preferred":[
         "Diekirch"
     ],
+    "name:tha_x_preferred":[
+        "\u0e14\u0e34\u0e01\u0e40\u0e04\u0e23\u0e34\u0e0a"
+    ],
     "name:tur_x_preferred":[
         "Diekirch"
     ],
     "name:ukr_x_preferred":[
         "\u0414\u0456\u043a\u0456\u0440\u0445"
+    ],
+    "name:ukr_x_variant":[
+        "\u0414\u0438\u043a\u0456\u0440\u0445"
     ],
     "name:urd_x_preferred":[
         "\u0688\u06cc\u06a9\u0631\u06a9"
@@ -333,7 +345,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1636501779,
+    "wof:lastmodified":1690938753,
     "wof:name":"Diekirch",
     "wof:parent_id":1125390659,
     "wof:placetype":"locality",

--- a/data/101/812/863/101812863.geojson
+++ b/data/101/812/863/101812863.geojson
@@ -69,6 +69,9 @@
     "name:ita_x_preferred":[
         "Beaufort"
     ],
+    "name:lim_x_preferred":[
+        "Beaufort"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Beefort"
     ],
@@ -111,6 +114,9 @@
     "name:swe_x_preferred":[
         "Beaufort"
     ],
+    "name:tur_x_preferred":[
+        "Beaufort"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u043e\u0444\u043e\u0440"
     ],
@@ -122,6 +128,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Beaufort"
+    ],
+    "name:zho_x_preferred":[
+        "\u535a\u798f\u5c14"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -191,7 +200,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1636501779,
+    "wof:lastmodified":1690938758,
     "wof:name":"Beaufort",
     "wof:parent_id":1125402081,
     "wof:placetype":"locality",

--- a/data/101/812/865/101812865.geojson
+++ b/data/101/812/865/101812865.geojson
@@ -43,7 +43,6 @@
         "Mertzig"
     ],
     "name:eng_x_variant":[
-        "Mertzig",
         "Haut-Merzig"
     ],
     "name:fas_x_preferred":[
@@ -66,6 +65,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng M\u00e4erzeg"
+    ],
+    "name:ltz_x_variant":[
+        "M\u00e4erzeg"
     ],
     "name:msa_x_preferred":[
         "Mertzig"
@@ -100,6 +102,9 @@
     "name:swe_x_preferred":[
         "Mertzig"
     ],
+    "name:tur_x_preferred":[
+        "Mertzig"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u0440\u0446\u0438\u0433"
     ],
@@ -108,6 +113,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Mertzig"
+    ],
+    "name:zho_x_preferred":[
+        "\u6885\u5c14\u9f50\u5e0c"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -177,7 +185,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732118,
+    "wof:lastmodified":1690938757,
     "wof:name":"Mertzig",
     "wof:parent_id":1125305933,
     "wof:placetype":"locality",

--- a/data/101/812/867/101812867.geojson
+++ b/data/101/812/867/101812867.geojson
@@ -60,6 +60,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Rammerech"
     ],
+    "name:ltz_x_variant":[
+        "Rammerech"
+    ],
     "name:msa_x_preferred":[
         "Rambrouch"
     ],
@@ -93,11 +96,17 @@
     "name:swe_x_preferred":[
         "Rambrouch"
     ],
+    "name:tur_x_preferred":[
+        "Rambrouch"
+    ],
     "name:ukr_x_preferred":[
         "\u0420\u0430\u043c\u0431\u0440\u0443\u0445"
     ],
     "name:zho_min_nan_x_preferred":[
         "Rambrouch"
+    ],
+    "name:zho_x_preferred":[
+        "\u6717\u5e03\u9c81\u514b"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -166,7 +175,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732119,
+    "wof:lastmodified":1690938754,
     "wof:name":"Rambrouch",
     "wof:parent_id":1125410765,
     "wof:placetype":"locality",

--- a/data/101/812/871/101812871.geojson
+++ b/data/101/812/871/101812871.geojson
@@ -63,8 +63,17 @@
     "name:ita_x_preferred":[
         "Berdorf"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d9\u30eb\u30c9\u30eb\u30d5"
+    ],
+    "name:lim_x_preferred":[
+        "Berdorf"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng B\u00e4erdref"
+    ],
+    "name:ltz_x_variant":[
+        "B\u00e4erdref"
     ],
     "name:msa_x_preferred":[
         "Berdorf"
@@ -99,6 +108,9 @@
     "name:swe_x_preferred":[
         "Berdorf"
     ],
+    "name:tur_x_preferred":[
+        "Berdorf"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0440\u0434\u043e\u0440\u0444"
     ],
@@ -107,6 +119,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Berdorf"
+    ],
+    "name:zho_x_preferred":[
+        "\u8d1d\u5c14\u591a\u592b"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -175,7 +190,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732121,
+    "wof:lastmodified":1690938756,
     "wof:name":"Berdorf",
     "wof:parent_id":1125350967,
     "wof:placetype":"locality",

--- a/data/101/812/873/101812873.geojson
+++ b/data/101/812/873/101812873.geojson
@@ -26,6 +26,15 @@
     "name:als_x_preferred":[
         "Iechternach"
     ],
+    "name:ara_x_preferred":[
+        "\u0627\u0634\u062a\u0631\u0646\u0627\u062e"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0634\u062a\u0631\u0646\u0627\u062e"
+    ],
+    "name:ast_x_preferred":[
+        "Echternach"
+    ],
     "name:aze_x_preferred":[
         "Externax"
     ],
@@ -74,6 +83,9 @@
     "name:gsw_x_preferred":[
         "Iechternach"
     ],
+    "name:hye_x_preferred":[
+        "\u0537\u056d\u057f\u0565\u0580\u0561\u0579"
+    ],
     "name:ido_x_preferred":[
         "Echternach"
     ],
@@ -94,6 +106,9 @@
     ],
     "name:kor_x_variant":[
         "\uc5d0\ud750\ud130\ub098\ud750"
+    ],
+    "name:lim_x_preferred":[
+        "Echternach"
     ],
     "name:lit_x_preferred":[
         "Echternachas"
@@ -125,6 +140,9 @@
     "name:por_x_preferred":[
         "Echternach"
     ],
+    "name:pus_x_preferred":[
+        "\u0627\u0634\u062a\u0631\u0646\u0627\u062e"
+    ],
     "name:ron_x_preferred":[
         "Echternach"
     ],
@@ -142,6 +160,9 @@
     ],
     "name:swe_x_preferred":[
         "Echternach"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e2d\u0e35\u0e22\u0e0a\u0e40\u0e17\u0e2d\u0e23\u0e4c\u0e19\u0e31\u0e04"
     ],
     "name:tur_x_preferred":[
         "Echternach"
@@ -251,7 +272,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732122,
+    "wof:lastmodified":1690938752,
     "wof:name":"Echternach",
     "wof:parent_id":1125303769,
     "wof:placetype":"locality",

--- a/data/101/812/877/101812877.geojson
+++ b/data/101/812/877/101812877.geojson
@@ -57,6 +57,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Biissen"
     ],
+    "name:ltz_x_variant":[
+        "Biissen"
+    ],
     "name:msa_x_preferred":[
         "Bissen"
     ],
@@ -85,6 +88,9 @@
         "Bissen"
     ],
     "name:swe_x_preferred":[
+        "Bissen"
+    ],
+    "name:tur_x_preferred":[
         "Bissen"
     ],
     "name:ukr_x_preferred":[
@@ -152,7 +158,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732123,
+    "wof:lastmodified":1690938756,
     "wof:name":"Bissen",
     "wof:parent_id":1125303385,
     "wof:placetype":"locality",

--- a/data/101/812/879/101812879.geojson
+++ b/data/101/812/879/101812879.geojson
@@ -51,8 +51,14 @@
     "name:ita_x_preferred":[
         "Consdorf"
     ],
+    "name:lim_x_preferred":[
+        "Consdorf"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Konsdref"
+    ],
+    "name:ltz_x_variant":[
+        "Konsdref"
     ],
     "name:msa_x_preferred":[
         "Consdorf"
@@ -72,6 +78,9 @@
     "name:por_x_preferred":[
         "Consdorf"
     ],
+    "name:pus_x_preferred":[
+        "\u06a9\u0648\u0646\u0632\u062f\u0631\u0648\u0641"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u043d\u0441\u0434\u043e\u0440\u0444"
     ],
@@ -84,11 +93,17 @@
     "name:swe_x_preferred":[
         "Consdorf"
     ],
+    "name:tur_x_preferred":[
+        "Consdorf"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043d\u0441\u0434\u043e\u0440\u0444"
     ],
     "name:urd_x_preferred":[
         "\u06a9\u0646\u0633\u062f\u0648\u0631\u0641"
+    ],
+    "name:zho_x_preferred":[
+        "\u5b54\u65af\u591a\u592b"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -152,7 +167,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732125,
+    "wof:lastmodified":1690938755,
     "wof:name":"Consdorf",
     "wof:parent_id":1125285639,
     "wof:placetype":"locality",

--- a/data/101/812/881/101812881.geojson
+++ b/data/101/812/881/101812881.geojson
@@ -93,8 +93,14 @@
     "name:swe_x_preferred":[
         "Useldange"
     ],
+    "name:tur_x_preferred":[
+        "Useldange"
+    ],
     "name:ukr_x_preferred":[
         "\u042e\u0441\u0435\u043b\u044c\u0434\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u4e8e\u585e\u5c14\u5f53\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -158,7 +164,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732126,
+    "wof:lastmodified":1690938753,
     "wof:name":"Useldange",
     "wof:parent_id":1125366387,
     "wof:placetype":"locality",

--- a/data/101/812/883/101812883.geojson
+++ b/data/101/812/883/101812883.geojson
@@ -63,6 +63,9 @@
     "name:deu_x_preferred":[
         "Mersch"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b5\u03c1\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Mersch"
     ],
@@ -105,6 +108,9 @@
     "name:gsw_x_preferred":[
         "Miersch"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e8\u05e9"
+    ],
     "name:hrv_x_preferred":[
         "Mersch"
     ],
@@ -128,6 +134,9 @@
     ],
     "name:ita_x_preferred":[
         "Mersch"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e1\u30eb\u30b7\u30e5"
     ],
     "name:kon_x_preferred":[
         "Mersch"
@@ -198,6 +207,9 @@
     "name:por_x_preferred":[
         "Mersch"
     ],
+    "name:pus_x_preferred":[
+        "\u0645\u0627\u064a\u0631\u0634"
+    ],
     "name:roh_x_preferred":[
         "Mersch"
     ],
@@ -229,6 +241,12 @@
         "Mersch"
     ],
     "name:swe_x_preferred":[
+        "Mersch"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e21\u0e35\u0e22\u0e23\u0e4c\u0e0a"
+    ],
+    "name:tur_x_preferred":[
         "Mersch"
     ],
     "name:ukr_x_preferred":[
@@ -330,7 +348,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732127,
+    "wof:lastmodified":1690938756,
     "wof:name":"Mersch",
     "wof:parent_id":1125286143,
     "wof:placetype":"locality",

--- a/data/101/812/885/101812885.geojson
+++ b/data/101/812/885/101812885.geojson
@@ -43,7 +43,6 @@
         "Lintgen"
     ],
     "name:eng_x_variant":[
-        "Lintgen",
         "Ferme Rouge"
     ],
     "name:fas_x_preferred":[
@@ -63,6 +62,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng L\u00ebntgen"
+    ],
+    "name:ltz_x_variant":[
+        "L\u00ebntgen"
     ],
     "name:msa_x_preferred":[
         "Lintgen"
@@ -97,11 +99,17 @@
     "name:swe_x_preferred":[
         "Lintgen"
     ],
+    "name:tur_x_preferred":[
+        "Lintgen"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0456\u043d\u0442\u0433\u0435\u043d"
     ],
     "name:zho_min_nan_x_preferred":[
         "Lintgen"
+    ],
+    "name:zho_x_preferred":[
+        "\u6797\u7279\u6839"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -171,7 +179,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732129,
+    "wof:lastmodified":1690938757,
     "wof:name":"Lintgen",
     "wof:parent_id":1125288915,
     "wof:placetype":"locality",

--- a/data/101/812/889/101812889.geojson
+++ b/data/101/812/889/101812889.geojson
@@ -36,6 +36,9 @@
     "name:eng_x_preferred":[
         "Junglinster"
     ],
+    "name:epo_x_preferred":[
+        "Junglinster"
+    ],
     "name:fas_x_preferred":[
         "\u06cc\u0648\u0646\u06af\u0644\u06cc\u0646\u0633\u062a\u0631"
     ],
@@ -48,8 +51,14 @@
     "name:ita_x_preferred":[
         "Junglinster"
     ],
+    "name:lit_x_preferred":[
+        "Junglinsteris"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Jongl\u00ebnster"
+    ],
+    "name:ltz_x_variant":[
+        "Jongl\u00ebnster"
     ],
     "name:msa_x_preferred":[
         "Junglinster"
@@ -84,8 +93,14 @@
     "name:swe_x_preferred":[
         "Junglinster"
     ],
+    "name:tur_x_preferred":[
+        "Junglinster"
+    ],
     "name:ukr_x_preferred":[
         "\u042e\u043d\u0433\u043b\u0456\u043d\u0441\u0442\u0435\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u6c38\u6797\u65af\u7279"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -149,7 +164,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732130,
+    "wof:lastmodified":1690938752,
     "wof:name":"Junglinster",
     "wof:parent_id":1125296455,
     "wof:placetype":"locality",

--- a/data/101/812/891/101812891.geojson
+++ b/data/101/812/891/101812891.geojson
@@ -57,6 +57,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Manternach"
     ],
+    "name:ltz_x_variant":[
+        "Manternach"
+    ],
     "name:msa_x_preferred":[
         "Manternach"
     ],
@@ -87,11 +90,17 @@
     "name:swe_x_preferred":[
         "Manternach"
     ],
+    "name:tur_x_preferred":[
+        "Manternach"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0430\u043d\u0442\u0435\u0440\u043d\u0430\u0445"
     ],
     "name:zho_min_nan_x_preferred":[
         "Manternach"
+    ],
+    "name:zho_x_preferred":[
+        "\u66fc\u7279\u7eb3\u8d6b"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -161,7 +170,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732132,
+    "wof:lastmodified":1690938757,
     "wof:name":"Manternach",
     "wof:parent_id":1125305331,
     "wof:placetype":"locality",

--- a/data/101/812/893/101812893.geojson
+++ b/data/101/812/893/101812893.geojson
@@ -51,8 +51,14 @@
     "name:ita_x_preferred":[
         "Koerich"
     ],
+    "name:lim_x_preferred":[
+        "Koerich"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng K\u00e4erch"
+    ],
+    "name:ltz_x_variant":[
+        "K\u00e4erch"
     ],
     "name:msa_x_preferred":[
         "Koerich"
@@ -87,6 +93,9 @@
     "name:swe_x_preferred":[
         "Koerich"
     ],
+    "name:tur_x_preferred":[
+        "Koerich"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0435\u0440\u0456\u0445"
     ],
@@ -98,6 +107,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Koerich"
+    ],
+    "name:zho_x_preferred":[
+        "\u514b\u91cc\u5e0c"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -163,7 +175,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732133,
+    "wof:lastmodified":1690938754,
     "wof:name":"Koerich",
     "wof:parent_id":1125366349,
     "wof:placetype":"locality",

--- a/data/101/812/895/101812895.geojson
+++ b/data/101/812/895/101812895.geojson
@@ -48,8 +48,14 @@
     "name:ita_x_preferred":[
         "Kehlen"
     ],
+    "name:lim_x_preferred":[
+        "Kehlen"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Kielen"
+    ],
+    "name:ltz_x_variant":[
+        "Kielen"
     ],
     "name:msa_x_preferred":[
         "Kehlen"
@@ -79,6 +85,9 @@
         "Kehlen"
     ],
     "name:swe_x_preferred":[
+        "Kehlen"
+    ],
+    "name:tur_x_preferred":[
         "Kehlen"
     ],
     "name:ukr_x_preferred":[
@@ -146,7 +155,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1642551743,
+    "wof:lastmodified":1690938753,
     "wof:name":"Kehlen",
     "wof:parent_id":1125376161,
     "wof:placetype":"locality",

--- a/data/101/812/899/101812899.geojson
+++ b/data/101/812/899/101812899.geojson
@@ -54,6 +54,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Sch\u00ebtter"
     ],
+    "name:ltz_x_variant":[
+        "Sch\u00ebtter"
+    ],
     "name:msa_x_preferred":[
         "Schuttrange"
     ],
@@ -84,8 +87,14 @@
     "name:swe_x_preferred":[
         "Schuttrange"
     ],
+    "name:tur_x_preferred":[
+        "Schuttrange"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0443\u0442\u0442\u0440\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u8bb8\u7279\u6717\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -149,7 +158,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732136,
+    "wof:lastmodified":1690938758,
     "wof:name":"Schuttrange",
     "wof:parent_id":1125375263,
     "wof:placetype":"locality",

--- a/data/101/812/901/101812901.geojson
+++ b/data/101/812/901/101812901.geojson
@@ -51,6 +51,9 @@
     "name:ita_x_preferred":[
         "Garnich"
     ],
+    "name:lim_x_preferred":[
+        "Garnich"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Garnech"
     ],
@@ -65,6 +68,9 @@
     ],
     "name:nds_x_preferred":[
         "Gemeen Garnich"
+    ],
+    "name:nds_x_variant":[
+        "Garnich"
     ],
     "name:nld_x_preferred":[
         "Garnich"
@@ -93,11 +99,17 @@
     "name:swe_x_preferred":[
         "Garnich"
     ],
+    "name:tur_x_preferred":[
+        "Garnich"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u0430\u0440\u043d\u0456\u0445"
     ],
     "name:zho_min_nan_x_preferred":[
         "Garnich"
+    ],
+    "name:zho_x_preferred":[
+        "\u52a0\u5c3c\u5e0c"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -167,7 +179,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732137,
+    "wof:lastmodified":1690938751,
     "wof:name":"Garnich",
     "wof:parent_id":1125284663,
     "wof:placetype":"locality",

--- a/data/101/812/907/101812907.geojson
+++ b/data/101/812/907/101812907.geojson
@@ -21,6 +21,9 @@
     "name:als_x_preferred":[
         "Dippech"
     ],
+    "name:aze_x_preferred":[
+        "Dippak"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0437\u0456\u043f\u0430\u0445"
     ],
@@ -60,8 +63,17 @@
     "name:ita_x_preferred":[
         "Dippach"
     ],
+    "name:jpn_x_preferred":[
+        "\u30c7\u30a3\u30c3\u30d1\u30c3\u30cf"
+    ],
+    "name:lim_x_preferred":[
+        "Dippach"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Dippech"
+    ],
+    "name:ltz_x_variant":[
+        "Dippech"
     ],
     "name:msa_x_preferred":[
         "Dippach"
@@ -87,6 +99,9 @@
     "name:por_x_preferred":[
         "Dippach"
     ],
+    "name:pus_x_preferred":[
+        "\u062f\u06cc\u067e\u0627\u062e"
+    ],
     "name:rus_x_preferred":[
         "\u0414\u0438\u043f\u043f\u0430\u0445"
     ],
@@ -97,6 +112,9 @@
         "Dippach"
     ],
     "name:swe_x_preferred":[
+        "Dippach"
+    ],
+    "name:tur_x_preferred":[
         "Dippach"
     ],
     "name:ukr_x_preferred":[
@@ -176,7 +194,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732138,
+    "wof:lastmodified":1690938751,
     "wof:name":"Dippach",
     "wof:parent_id":1125285649,
     "wof:placetype":"locality",

--- a/data/101/812/909/101812909.geojson
+++ b/data/101/812/909/101812909.geojson
@@ -48,6 +48,9 @@
     "name:gsw_x_preferred":[
         "Konter"
     ],
+    "name:gsw_x_variant":[
+        "Conter"
+    ],
     "name:hun_x_preferred":[
         "Contern"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng Konter"
+    ],
+    "name:ltz_x_variant":[
+        "Conter"
     ],
     "name:msa_x_preferred":[
         "Contern"
@@ -78,6 +84,9 @@
     "name:por_x_preferred":[
         "Contern"
     ],
+    "name:pus_x_preferred":[
+        "\u06a9\u0648\u0646\u067c\u0631\u0646"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u043d\u0442\u0435\u0440\u043d"
     ],
@@ -90,11 +99,17 @@
     "name:swe_x_preferred":[
         "Contern"
     ],
+    "name:tur_x_preferred":[
+        "Contern"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043d\u0442\u0435\u0440\u043d"
     ],
     "name:zho_min_nan_x_preferred":[
         "Contern"
+    ],
+    "name:zho_x_preferred":[
+        "\u5b54\u7279\u6069"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -164,7 +179,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732139,
+    "wof:lastmodified":1690938751,
     "wof:name":"Contern",
     "wof:parent_id":1745980849,
     "wof:placetype":"locality",

--- a/data/101/812/911/101812911.geojson
+++ b/data/101/812/911/101812911.geojson
@@ -63,6 +63,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Leideleng"
     ],
+    "name:ltz_x_variant":[
+        "Leideleng"
+    ],
     "name:msa_x_preferred":[
         "Leudelange"
     ],
@@ -93,11 +96,17 @@
     "name:swe_x_preferred":[
         "Leudelange"
     ],
+    "name:tur_x_preferred":[
+        "Leudelange"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u044c\u043e\u0434\u0435\u043b\u0430\u043d\u0436"
     ],
     "name:zho_min_nan_x_preferred":[
         "Leudelange"
+    ],
+    "name:zho_x_preferred":[
+        "\u52d2\u5fb7\u6717\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -163,7 +172,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732141,
+    "wof:lastmodified":1690938759,
     "wof:name":"Leudelange",
     "wof:parent_id":1125396325,
     "wof:placetype":"locality",

--- a/data/101/812/913/101812913.geojson
+++ b/data/101/812/913/101812913.geojson
@@ -36,6 +36,9 @@
     "name:eng_x_preferred":[
         "Dalheim"
     ],
+    "name:epo_x_preferred":[
+        "Dalheim"
+    ],
     "name:fas_x_preferred":[
         "\u062f\u0627\u0644\u0647\u0627\u06cc\u0645"
     ],
@@ -91,6 +94,9 @@
         "Dalheim"
     ],
     "name:swe_x_preferred":[
+        "Dalheim"
+    ],
+    "name:tur_x_preferred":[
         "Dalheim"
     ],
     "name:ukr_x_preferred":[
@@ -161,7 +167,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732142,
+    "wof:lastmodified":1690938755,
     "wof:name":"Dalheim",
     "wof:parent_id":1125283997,
     "wof:placetype":"locality",

--- a/data/101/812/915/101812915.geojson
+++ b/data/101/812/915/101812915.geojson
@@ -60,6 +60,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Monnerech"
     ],
+    "name:ltz_x_variant":[
+        "Monnerech"
+    ],
     "name:msa_x_preferred":[
         "Mondercange"
     ],
@@ -96,11 +99,17 @@
     "name:swe_x_preferred":[
         "Mondercange"
     ],
+    "name:tur_x_preferred":[
+        "Mondercange"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u043e\u043d\u0434\u0435\u0440\u043a\u0430\u043d\u0436"
     ],
     "name:zho_min_nan_x_preferred":[
         "Mondercange"
+    ],
+    "name:zho_x_preferred":[
+        "\u8499\u4ee3\u5eb7\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -167,7 +176,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732143,
+    "wof:lastmodified":1690938755,
     "wof:name":"Mondercange",
     "wof:parent_id":1125293961,
     "wof:placetype":"locality",

--- a/data/101/812/917/101812917.geojson
+++ b/data/101/812/917/101812917.geojson
@@ -21,6 +21,9 @@
     "name:als_x_preferred":[
         "Beetebuerg"
     ],
+    "name:ara_x_preferred":[
+        "\u0628\u062a\u0645\u0628\u0648\u0631\u063a"
+    ],
     "name:bel_x_preferred":[
         "\u0411\u0435\u0442\u044d\u043c\u0431\u0443\u0440"
     ],
@@ -43,6 +46,9 @@
         "\u0628\u062a\u0645\u0628\u0648\u0631\u06af"
     ],
     "name:fra_x_preferred":[
+        "Bettembourg"
+    ],
+    "name:fur_x_preferred":[
         "Bettembourg"
     ],
     "name:gsw_x_preferred":[
@@ -105,8 +111,14 @@
     "name:swe_x_preferred":[
         "Bettembourg"
     ],
+    "name:tur_x_preferred":[
+        "Bettembourg"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0442\u0442\u0435\u043c\u0431\u0443\u0440\u0433"
+    ],
+    "name:zho_x_preferred":[
+        "\u8d1d\u5510\u5821"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -166,7 +178,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732145,
+    "wof:lastmodified":1690938759,
     "wof:name":"Bettembourg",
     "wof:parent_id":1125357423,
     "wof:placetype":"locality",

--- a/data/101/812/919/101812919.geojson
+++ b/data/101/812/919/101812919.geojson
@@ -75,6 +75,9 @@
     "name:por_x_preferred":[
         "Frisange"
     ],
+    "name:pus_x_preferred":[
+        "\u0641\u0631\u064a\u0633\u06d0\u0646\u062c"
+    ],
     "name:rus_x_preferred":[
         "\u0424\u0440\u0438\u0437\u0430\u043d\u0436"
     ],
@@ -84,8 +87,17 @@
     "name:swe_x_preferred":[
         "Frisange"
     ],
+    "name:tur_x_preferred":[
+        "Frisange"
+    ],
     "name:ukr_x_preferred":[
         "\u0424\u0440\u0456\u0437\u0430\u043d\u0436"
+    ],
+    "name:ukr_x_variant":[
+        "\u0424\u0440\u0438\u0437\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u5f17\u91cc\u6851\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -145,7 +157,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732146,
+    "wof:lastmodified":1690938759,
     "wof:name":"Frisange",
     "wof:parent_id":1125410585,
     "wof:placetype":"locality",

--- a/data/101/813/323/101813323.geojson
+++ b/data/101/813/323/101813323.geojson
@@ -59,6 +59,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Wuermeldeng"
     ],
+    "name:ltz_x_variant":[
+        "Wuermer"
+    ],
     "name:msa_x_preferred":[
         "Wormeldange"
     ],
@@ -86,8 +89,14 @@
     "name:swe_x_preferred":[
         "Wormeldange"
     ],
+    "name:tur_x_preferred":[
+        "Wormeldange"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u043e\u0440\u043c\u0435\u043b\u044c\u0434\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u6c83\u6885\u5c14\u5f53\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*Rheinland-Pfalz",
@@ -171,7 +180,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732149,
+    "wof:lastmodified":1690938760,
     "wof:name":"Wormeldange",
     "wof:parent_id":1125311551,
     "wof:placetype":"locality",

--- a/data/101/839/151/101839151.geojson
+++ b/data/101/839/151/101839151.geojson
@@ -57,6 +57,9 @@
     "name:gsw_x_preferred":[
         "Ierpeldeng"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05e8\u05e4\u05dc\u05d3\u05d0\u05e0\u05d2'"
+    ],
     "name:ita_x_preferred":[
         "Erpeldange"
     ],
@@ -90,6 +93,9 @@
     "name:por_x_preferred":[
         "Erpeldange"
     ],
+    "name:pus_x_preferred":[
+        "\u0627\u06d0\u0631\u067e\u0644\u062f\u0627\u0646\u062c"
+    ],
     "name:rus_x_preferred":[
         "\u042d\u0440\u043f\u0435\u043b\u044c\u0434\u0430\u043d\u0436"
     ],
@@ -99,11 +105,17 @@
     "name:swe_x_preferred":[
         "Erpeldange"
     ],
+    "name:tur_x_preferred":[
+        "Erpeldange"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u0440\u043f\u0435\u043b\u044c\u0434\u0430\u043d\u0436"
     ],
     "name:zho_min_nan_x_preferred":[
         "Erpeldange"
+    ],
+    "name:zho_x_preferred":[
+        "\u53d9\u5c14\u6cb3\u7554\u57c3\u4f69\u5c14\u5f53\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -173,7 +185,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732150,
+    "wof:lastmodified":1690938762,
     "wof:name":"Erpeldange-sur-S\u00fbre",
     "wof:parent_id":1125386695,
     "wof:placetype":"locality",

--- a/data/101/839/153/101839153.geojson
+++ b/data/101/839/153/101839153.geojson
@@ -99,6 +99,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Ettelbr\u00e9ck"
     ],
+    "name:ltz_x_variant":[
+        "Ettelbr\u00e9ck"
+    ],
     "name:msa_x_preferred":[
         "Ettelbruck"
     ],
@@ -125,6 +128,9 @@
     ],
     "name:por_x_preferred":[
         "Ettelbruck"
+    ],
+    "name:pus_x_preferred":[
+        "\u0627\u062a\u0644 \u0628\u0631\u0648\u06a9"
     ],
     "name:ron_x_preferred":[
         "Ettelbruck"
@@ -239,7 +245,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732151,
+    "wof:lastmodified":1690938763,
     "wof:name":"Ettelbruck",
     "wof:parent_id":1125311519,
     "wof:placetype":"locality",

--- a/data/101/839/799/101839799.geojson
+++ b/data/101/839/799/101839799.geojson
@@ -36,6 +36,9 @@
     "name:eng_x_preferred":[
         "Mertert"
     ],
+    "name:epo_x_preferred":[
+        "Mertert"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0631\u062a\u0631\u062a"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng M\u00e4ertert"
+    ],
+    "name:ltz_x_variant":[
+        "M\u00e4ertert"
     ],
     "name:msa_x_preferred":[
         "Mertert"
@@ -90,8 +96,14 @@
     "name:swe_x_preferred":[
         "Mertert"
     ],
+    "name:tur_x_preferred":[
+        "Mertert"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u0440\u0442\u0435\u0440\u0442"
+    ],
+    "name:zho_x_preferred":[
+        "\u6885\u5c14\u6cf0\u7279"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -155,7 +167,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732153,
+    "wof:lastmodified":1690938761,
     "wof:name":"Mertert",
     "wof:parent_id":1125366357,
     "wof:placetype":"locality",

--- a/data/101/839/801/101839801.geojson
+++ b/data/101/839/801/101839801.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u063a\u0631\u064a\u0641\u064a\u0646\u0645\u0627\u062a\u0634\u064a\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Grevenmacher"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u0440\u044d\u0432\u0435\u043d\u043c\u0430\u0445\u0435\u0440"
     ],
@@ -48,6 +51,9 @@
     "name:eng_x_preferred":[
         "Grevenmacher"
     ],
+    "name:epo_x_preferred":[
+        "Grevenmacher"
+    ],
     "name:eus_x_preferred":[
         "Grevenmacher"
     ],
@@ -68,6 +74,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0917\u094d\u0930\u0948\u0935\u0947\u0928\u092e\u093e\u0915\u0930"
+    ],
+    "name:hrv_x_preferred":[
+        "Grevenmacher"
     ],
     "name:hun_x_preferred":[
         "Grevenmacher"
@@ -106,6 +115,9 @@
         "Grevenmacher"
     ],
     "name:nan_x_preferred":[
+        "Grevenmacher"
+    ],
+    "name:nds_x_preferred":[
         "Grevenmacher"
     ],
     "name:nld_x_preferred":[
@@ -322,7 +334,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1636501779,
+    "wof:lastmodified":1690938765,
     "wof:name":"Grevenmacher",
     "wof:parent_id":1125415535,
     "wof:placetype":"locality",

--- a/data/101/839/803/101839803.geojson
+++ b/data/101/839/803/101839803.geojson
@@ -24,11 +24,17 @@
     "name:ara_x_preferred":[
         "\u0625\u064a\u0633\u0634 \u0633\u0648\u0631 \u0623\u0644\u0632\u064a\u062a\u064a"
     ],
+    "name:ast_x_preferred":[
+        "Esch-sur-Alzette"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u0448-\u0441\u044e\u0440-\u0410\u043b\u044c\u0437\u0435\u0442"
     ],
     "name:bel_x_variant":[
         "\u042d\u0448-\u0441\u044e\u0440-\u0410\u043b\u044c\u0437\u044d\u0442"
+    ],
+    "name:bis_x_preferred":[
+        "Esch-sur-Alzette"
     ],
     "name:cat_x_preferred":[
         "Esch-sur-Alzette"
@@ -38,6 +44,9 @@
     ],
     "name:ces_x_preferred":[
         "Esch-sur-Alzette"
+    ],
+    "name:chv_x_preferred":[
+        "\u042d\u0448-\u0441\u044e\u0440-\u0410\u043b\u044c\u0437\u0435\u0442\u0442"
     ],
     "name:dan_x_preferred":[
         "Esch-sur-Alzette"
@@ -64,6 +73,9 @@
     "name:epo_x_preferred":[
         "Esch-sur-Alzette"
     ],
+    "name:est_x_preferred":[
+        "Esch-sur-Alzette"
+    ],
     "name:eus_x_preferred":[
         "Esch-sur-Alzette"
     ],
@@ -82,6 +94,12 @@
     "name:fra_x_preferred":[
         "Esch-sur-Alzette"
     ],
+    "name:fur_x_preferred":[
+        "Esch-sur-Alzette"
+    ],
+    "name:gle_x_preferred":[
+        "Esch-sur-Alzette"
+    ],
     "name:gsw_x_preferred":[
         "Esch-Uelzecht"
     ],
@@ -90,6 +108,9 @@
     ],
     "name:hun_x_preferred":[
         "Esch-sur-Alzette"
+    ],
+    "name:hye_x_preferred":[
+        "\u0537\u0577-\u057d\u0575\u0578\u0582\u0580-\u0531\u056c\u0566\u0565\u057f"
     ],
     "name:ido_x_preferred":[
         "Esch-sur-Alzette"
@@ -160,6 +181,9 @@
     "name:por_x_preferred":[
         "Esch-sur-Alzette"
     ],
+    "name:pus_x_preferred":[
+        "\u0627\u0634-\u0633\u0648\u0631-\u0627\u0644\u0632\u062a"
+    ],
     "name:ron_x_preferred":[
         "Esch-sur-Alzette"
     ],
@@ -175,6 +199,9 @@
     "name:slk_x_preferred":[
         "Esch-sur-Alzette"
     ],
+    "name:slv_x_preferred":[
+        "Esch-sur-Alzette"
+    ],
     "name:spa_x_preferred":[
         "Esch-sur-Alzette"
     ],
@@ -186,6 +213,12 @@
     ],
     "name:swe_x_preferred":[
         "Esch-sur-Alzette"
+    ],
+    "name:szl_x_preferred":[
+        "Esch-sur-Alzette"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e41\u0e2d\u0e0c\u0e27\u0e25\u0e15\u0e4c\u0e40\u0e0b\u0e34\u0e0a\u0e17\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Esch-sur-Alzette"
@@ -201,6 +234,12 @@
     ],
     "name:vol_x_preferred":[
         "Esch-sur-Alzette"
+    ],
+    "name:wuu_x_preferred":[
+        "\u963f\u5c14\u6cfd\u7279\u6cb3\u7554\u57c3\u65bd"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d4\u10e8-\u10e1\u10d8\u10e3\u10e0-\u10d0\u10da\u10d6\u10d4\u10e2\u10d8"
     ],
     "name:zho_min_nan_x_preferred":[
         "Esch-sur-Alzette"
@@ -274,7 +313,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732155,
+    "wof:lastmodified":1690938762,
     "wof:name":"Esch-sur-Alzette",
     "wof:parent_id":1125366319,
     "wof:placetype":"locality",

--- a/data/101/839/805/101839805.geojson
+++ b/data/101/839/805/101839805.geojson
@@ -93,10 +93,16 @@
     "name:slk_x_preferred":[
         "Kayl"
     ],
+    "name:spa_x_preferred":[
+        "Kayl"
+    ],
     "name:swa_x_preferred":[
         "Kayl"
     ],
     "name:swe_x_preferred":[
+        "Kayl"
+    ],
+    "name:tur_x_preferred":[
         "Kayl"
     ],
     "name:ukr_x_preferred":[
@@ -104,6 +110,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Kayl"
+    ],
+    "name:zho_x_preferred":[
+        "\u51ef\u52d2"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -170,7 +179,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732156,
+    "wof:lastmodified":1690938763,
     "wof:name":"Kayl",
     "wof:parent_id":1125407267,
     "wof:placetype":"locality",

--- a/data/101/839/807/101839807.geojson
+++ b/data/101/839/807/101839807.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0648\u062f\u064a\u0644\u0627\u0646\u062c"
     ],
+    "name:ast_x_preferred":[
+        "Dudelange"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0437\u044e\u0434\u0437\u0435\u043b\u0430\u043d\u0436"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:diq_x_preferred":[
         "Dudelange"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03bf\u03c5\u03bd\u03c4\u03b5\u03bb\u03ac\u03bd\u03b6"
     ],
     "name:eng_x_preferred":[
         "Dudelange"
@@ -108,6 +114,9 @@
     "name:por_x_preferred":[
         "Dudelange"
     ],
+    "name:pus_x_preferred":[
+        "\u062f\u0648\u062f\u0644\u0627\u0646\u0698"
+    ],
     "name:ron_x_preferred":[
         "Dudelange"
     ],
@@ -129,6 +138,9 @@
     "name:swe_x_preferred":[
         "Dudelange"
     ],
+    "name:szl_x_preferred":[
+        "Dudelange"
+    ],
     "name:tur_x_preferred":[
         "Dudelange"
     ],
@@ -143,6 +155,9 @@
     ],
     "name:zho_x_preferred":[
         "\u675c\u5fb7\u862d\u5091"
+    ],
+    "name:zho_x_variant":[
+        "\u8fea\u5fb7\u6717\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -202,7 +217,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732158,
+    "wof:lastmodified":1690938764,
     "wof:name":"Dudelange",
     "wof:parent_id":1125357415,
     "wof:placetype":"locality",

--- a/data/101/839/809/101839809.geojson
+++ b/data/101/839/809/101839809.geojson
@@ -20,6 +20,9 @@
     "name:als_x_preferred":[
         "R\u00ebmeleng"
     ],
+    "name:ast_x_preferred":[
+        "Rumelange"
+    ],
     "name:bel_x_preferred":[
         "\u0420\u0443\u043c\u0435\u043b\u0430\u043d\u0436"
     ],
@@ -110,6 +113,9 @@
     "name:por_x_preferred":[
         "Rumelange"
     ],
+    "name:pus_x_preferred":[
+        "\u0631\u0648\u0645\u0644\u0627\u0646\u0698"
+    ],
     "name:ron_x_preferred":[
         "Rumelange"
     ],
@@ -119,10 +125,16 @@
     "name:slk_x_preferred":[
         "Rumelange"
     ],
+    "name:spa_x_preferred":[
+        "Rumelange"
+    ],
     "name:srp_x_preferred":[
         "\u0420\u0443\u043c\u0435\u043b\u0430\u043d\u0436"
     ],
     "name:swe_x_preferred":[
+        "Rumelange"
+    ],
+    "name:tur_x_preferred":[
         "Rumelange"
     ],
     "name:ukr_x_preferred":[
@@ -203,7 +215,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732159,
+    "wof:lastmodified":1690938764,
     "wof:name":"Rumelange",
     "wof:parent_id":1125321401,
     "wof:placetype":"locality",

--- a/data/101/839/813/101839813.geojson
+++ b/data/101/839/813/101839813.geojson
@@ -105,6 +105,9 @@
     "name:swe_x_preferred":[
         "P\u00e9tange"
     ],
+    "name:tur_x_preferred":[
+        "P\u00e9tange"
+    ],
     "name:ukr_x_preferred":[
         "\u041f\u0435\u0442\u0430\u043d\u0436"
     ],
@@ -113,6 +116,9 @@
     ],
     "name:wln_x_preferred":[
         "Petindje"
+    ],
+    "name:zho_x_preferred":[
+        "\u4f69\u5510\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -172,7 +178,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732160,
+    "wof:lastmodified":1690938763,
     "wof:name":"P\u00e9tange",
     "wof:parent_id":1125283405,
     "wof:placetype":"locality",

--- a/data/101/839/817/101839817.geojson
+++ b/data/101/839/817/101839817.geojson
@@ -222,6 +222,9 @@
     "name:ukr_x_preferred":[
         "\u0414\u0456\u0444\u0444\u0435\u0440\u0434\u0430\u043d\u0436"
     ],
+    "name:ukr_x_variant":[
+        "\u0414\u0438\u0444\u0444\u0435\u0440\u0434\u0430\u043d\u0436"
+    ],
     "name:und_x_variant":[
         "Differdingen"
     ],
@@ -307,7 +310,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732162,
+    "wof:lastmodified":1690938762,
     "wof:name":"Differdange",
     "wof:parent_id":1125280445,
     "wof:placetype":"locality",

--- a/data/101/839/865/101839865.geojson
+++ b/data/101/839/865/101839865.geojson
@@ -23,6 +23,12 @@
     "name:als_x_preferred":[
         "R\u00e9imech"
     ],
+    "name:ast_x_preferred":[
+        "Remich"
+    ],
+    "name:aze_x_preferred":[
+        "Remix"
+    ],
     "name:bel_x_preferred":[
         "\u0420\u044d\u043c\u0456\u0445"
     ],
@@ -42,6 +48,9 @@
         "Remich"
     ],
     "name:eng_x_preferred":[
+        "Remich"
+    ],
+    "name:epo_x_preferred":[
         "Remich"
     ],
     "name:eus_x_preferred":[
@@ -64,6 +73,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10e0\u10d4\u10db\u10d8\u10ee\u10d8"
+    ],
+    "name:kor_x_preferred":[
+        "\ub808\ubbf8\ud788"
     ],
     "name:lit_x_preferred":[
         "Remichas"
@@ -98,6 +110,9 @@
     "name:por_x_preferred":[
         "Remich"
     ],
+    "name:pus_x_preferred":[
+        "\u0631\u0645\u06cc\u0634"
+    ],
     "name:ron_x_preferred":[
         "Remich"
     ],
@@ -114,6 +129,12 @@
         "\u0420\u0435\u0458\u043c\u0435\u0445"
     ],
     "name:swe_x_preferred":[
+        "Remich"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e23\u0e47\u0e22\u0e40\u0e21\u0e34\u0e0a"
+    ],
+    "name:tur_x_preferred":[
         "Remich"
     ],
     "name:ukr_x_preferred":[
@@ -212,7 +233,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732163,
+    "wof:lastmodified":1690938765,
     "wof:name":"Remich",
     "wof:parent_id":1125327261,
     "wof:placetype":"locality",

--- a/data/101/845/555/101845555.geojson
+++ b/data/101/845/555/101845555.geojson
@@ -21,6 +21,9 @@
     "name:als_x_preferred":[
         "Housen"
     ],
+    "name:ast_x_preferred":[
+        "Hosingen"
+    ],
     "name:bel_x_preferred":[
         "\u0425\u043e\u0437\u0456\u043d\u0433\u0435\u043d"
     ],
@@ -31,6 +34,9 @@
         "Hosingen"
     ],
     "name:ceb_x_preferred":[
+        "Hosingen"
+    ],
+    "name:ces_x_preferred":[
         "Hosingen"
     ],
     "name:dan_x_preferred":[
@@ -45,6 +51,9 @@
     "name:eng_x_variant":[
         "Hosingen"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0633\u06cc\u0646\u06af\u0646"
+    ],
     "name:fra_x_preferred":[
         "Hosingen"
     ],
@@ -56,6 +65,9 @@
     ],
     "name:ita_x_preferred":[
         "Hosingen"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30db\u30fc\u30b7\u30f3\u30b2\u30f3"
     ],
     "name:lim_x_preferred":[
         "Hosinge"
@@ -93,6 +105,9 @@
     "name:swe_x_preferred":[
         "Hosingen"
     ],
+    "name:tur_x_preferred":[
+        "Hosingen"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u043e\u0437\u0456\u043d\u0433\u0435\u043d"
     ],
@@ -101,6 +116,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8d6b\u8f9b\u6839"
+    ],
+    "name:zho_x_variant":[
+        "\u970d\u8f9b\u6839"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -165,7 +183,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732164,
+    "wof:lastmodified":1690938749,
     "wof:name":"Parc Hosingen",
     "wof:parent_id":1125324097,
     "wof:placetype":"locality",

--- a/data/101/845/559/101845559.geojson
+++ b/data/101/845/559/101845559.geojson
@@ -77,6 +77,9 @@
     "name:kat_x_preferred":[
         "\u10d5\u10d8\u10d0\u10dc\u10d3\u10d4\u10dc\u10d8"
     ],
+    "name:lat_x_preferred":[
+        "Vianda"
+    ],
     "name:lit_x_preferred":[
         "Viandenas"
     ],
@@ -110,6 +113,9 @@
     "name:por_x_preferred":[
         "Vianden"
     ],
+    "name:pus_x_preferred":[
+        "\u0648\u06cc\u0627\u0646\u062f\u0646"
+    ],
     "name:ron_x_preferred":[
         "Vianden"
     ],
@@ -126,6 +132,9 @@
         "\u0412\u0438\u0458\u0430\u043d\u0434\u0435\u043d"
     ],
     "name:swe_x_preferred":[
+        "Vianden"
+    ],
+    "name:tur_x_preferred":[
         "Vianden"
     ],
     "name:ukr_x_preferred":[
@@ -231,7 +240,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732166,
+    "wof:lastmodified":1690938748,
     "wof:name":"Vianden",
     "wof:parent_id":1125303779,
     "wof:placetype":"locality",

--- a/data/101/845/561/101845561.geojson
+++ b/data/101/845/561/101845561.geojson
@@ -24,6 +24,9 @@
     "name:bel_x_preferred":[
         "\u0420\u044d\u0434\u0430\u043d\u0436-\u0441\u044e\u0440-\u0410\u0442\u044d\u0440\u0442"
     ],
+    "name:bul_x_preferred":[
+        "\u0420\u0435\u0434\u0430\u043d\u0436"
+    ],
     "name:cat_x_preferred":[
         "Redange"
     ],
@@ -65,6 +68,12 @@
     "name:fra_x_preferred":[
         "Redange"
     ],
+    "name:fra_x_variant":[
+        "Redange-sur-Attert"
+    ],
+    "name:gle_x_preferred":[
+        "Redange"
+    ],
     "name:gsw_x_preferred":[
         "R\u00e9iden"
     ],
@@ -74,8 +83,14 @@
     "name:ita_x_preferred":[
         "Redange"
     ],
+    "name:jpn_x_preferred":[
+        "\u30eb\u30c0\u30f3\u30b8\u30e5"
+    ],
     "name:kor_x_preferred":[
         "\ub808\ub2f9\uc8fc"
+    ],
+    "name:lim_x_preferred":[
+        "Redange"
     ],
     "name:ltz_x_preferred":[
         "R\u00e9iden"
@@ -122,11 +137,17 @@
     "name:swe_x_preferred":[
         "Redange-sur-Attert"
     ],
+    "name:tur_x_preferred":[
+        "Redange"
+    ],
     "name:ukr_x_preferred":[
         "\u0420\u0435\u0434\u0430\u043d\u0436"
     ],
     "name:zho_min_nan_x_preferred":[
         "Redange"
+    ],
+    "name:zho_x_preferred":[
+        "\u96f7\u5f53\u65e5"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -196,7 +217,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732167,
+    "wof:lastmodified":1690938748,
     "wof:name":"Redange/Attert",
     "wof:parent_id":1125402395,
     "wof:placetype":"locality",

--- a/data/101/845/563/101845563.geojson
+++ b/data/101/845/563/101845563.geojson
@@ -36,6 +36,9 @@
     "name:deu_x_preferred":[
         "Beckerich"
     ],
+    "name:diq_x_preferred":[
+        "Beckerich"
+    ],
     "name:eng_x_preferred":[
         "Beckerich"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng Biekerech"
+    ],
+    "name:ltz_x_variant":[
+        "Biekerech"
     ],
     "name:msa_x_preferred":[
         "Beckerich"
@@ -90,8 +96,14 @@
     "name:swe_x_preferred":[
         "Beckerich"
     ],
+    "name:tur_x_preferred":[
+        "Beckerich"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043a\u0435\u0440\u0456\u0445"
+    ],
+    "name:zho_x_preferred":[
+        "\u8d1d\u514b\u91cc\u5e0c"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -155,7 +167,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732169,
+    "wof:lastmodified":1690938749,
     "wof:name":"Beckerich",
     "wof:parent_id":1125325865,
     "wof:placetype":"locality",

--- a/data/101/845/565/101845565.geojson
+++ b/data/101/845/565/101845565.geojson
@@ -40,7 +40,6 @@
         "Habscht"
     ],
     "name:eng_x_variant":[
-        "Habscht",
         "Hobscheid"
     ],
     "name:fas_x_preferred":[
@@ -57,6 +56,12 @@
     ],
     "name:ita_x_preferred":[
         "Hobscheid"
+    ],
+    "name:ita_x_variant":[
+        "Habscht"
+    ],
+    "name:lim_x_preferred":[
+        "Habscht"
     ],
     "name:lit_x_preferred":[
         "Hob\u0161eidas"
@@ -102,6 +107,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0425\u043e\u0431\u0448\u0430\u0439\u0434"
+    ],
+    "name:zho_x_preferred":[
+        "\u54c8\u5e03\u65bd\u7279"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -165,7 +173,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732170,
+    "wof:lastmodified":1690938749,
     "wof:name":"Habscht",
     "wof:parent_id":1125284213,
     "wof:placetype":"locality",

--- a/data/101/845/567/101845567.geojson
+++ b/data/101/845/567/101845567.geojson
@@ -78,8 +78,14 @@
     "name:swe_x_preferred":[
         "Weiler-la-Tour"
     ],
+    "name:tur_x_preferred":[
+        "Weiler-la-Tour"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u0439\u043b\u0435\u0440-\u043b\u0430-\u0422\u0443\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u9b4f\u52d2\u62c9\u5716\u723e"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -143,7 +149,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732171,
+    "wof:lastmodified":1690938748,
     "wof:name":"Weiler-la-Tour",
     "wof:parent_id":1125285789,
     "wof:placetype":"locality",

--- a/data/101/853/467/101853467.geojson
+++ b/data/101/853/467/101853467.geojson
@@ -51,6 +51,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Waldbriedemes"
     ],
+    "name:ltz_x_variant":[
+        "Waldbriedemes"
+    ],
     "name:msa_x_preferred":[
         "Waldbredimus"
     ],
@@ -81,8 +84,14 @@
     "name:swe_x_preferred":[
         "Waldbredimus"
     ],
+    "name:tur_x_preferred":[
+        "Waldbredimus"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u043b\u044c\u0434\u0431\u0440\u0435\u0434\u0456\u043c\u044e"
+    ],
+    "name:zho_x_preferred":[
+        "\u74e6\u5c14\u5fb7\u5e03\u96f7\u8fea\u7a46\u65af"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -148,7 +157,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732173,
+    "wof:lastmodified":1690938760,
     "wof:name":"Waldbredimus",
     "wof:parent_id":1125288845,
     "wof:placetype":"locality",

--- a/data/101/854/569/101854569.geojson
+++ b/data/101/854/569/101854569.geojson
@@ -27,6 +27,9 @@
     "name:cat_x_preferred":[
         "Betzdorf"
     ],
+    "name:ces_x_preferred":[
+        "Betzdorf"
+    ],
     "name:dan_x_preferred":[
         "Betzdorf"
     ],
@@ -45,6 +48,9 @@
     "name:gsw_x_preferred":[
         "Betzder"
     ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05e6\u05d3\u05e8"
+    ],
     "name:hun_x_preferred":[
         "Betzdorf"
     ],
@@ -56,6 +62,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng Betzder"
+    ],
+    "name:ltz_x_variant":[
+        "Betzder"
     ],
     "name:msa_x_preferred":[
         "Betzdorf"
@@ -82,6 +91,9 @@
         "Betzdorf"
     ],
     "name:swe_x_preferred":[
+        "Betzdorf"
+    ],
+    "name:tur_x_preferred":[
         "Betzdorf"
     ],
     "name:ukr_x_preferred":[
@@ -160,7 +172,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732174,
+    "wof:lastmodified":1690938760,
     "wof:name":"Betzdorf",
     "wof:parent_id":1125325873,
     "wof:placetype":"locality",

--- a/data/101/854/571/101854571.geojson
+++ b/data/101/854/571/101854571.geojson
@@ -52,7 +52,8 @@
         "Fluessweller"
     ],
     "name:ltz_x_variant":[
-        "Gemeng Fluessweller"
+        "Gemeng Fluessweller",
+        "Fluessweiler"
     ],
     "name:msa_x_preferred":[
         "Flaxweiler"
@@ -81,8 +82,14 @@
     "name:swe_x_preferred":[
         "Flaxweiler"
     ],
+    "name:tur_x_preferred":[
+        "Flaxweiler"
+    ],
     "name:ukr_x_preferred":[
         "\u0424\u043b\u0430\u043a\u0441\u0432\u0430\u0439\u043b\u0435\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u5f17\u62c9\u514b\u65af\u97e6\u52d2"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -148,7 +155,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732175,
+    "wof:lastmodified":1690938761,
     "wof:name":"Flaxweiler",
     "wof:parent_id":1125284029,
     "wof:placetype":"locality",

--- a/data/101/854/573/101854573.geojson
+++ b/data/101/854/573/101854573.geojson
@@ -37,7 +37,6 @@
         "Lenningen"
     ],
     "name:eng_x_variant":[
-        "Lenningen",
         "Ihnen"
     ],
     "name:fas_x_preferred":[
@@ -52,8 +51,14 @@
     "name:ita_x_preferred":[
         "Lenningen"
     ],
+    "name:lit_x_preferred":[
+        "Leningenas"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Lenneng"
+    ],
+    "name:ltz_x_variant":[
+        "Lenneng"
     ],
     "name:msa_x_preferred":[
         "Lenningen"
@@ -88,8 +93,14 @@
     "name:swe_x_preferred":[
         "Lenningen"
     ],
+    "name:tur_x_preferred":[
+        "Lenningen"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0435\u043d\u043d\u0456\u043d\u0433\u0435\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u4f26\u5b81\u6839"
     ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
@@ -155,7 +166,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732177,
+    "wof:lastmodified":1690938761,
     "wof:name":"Lenningen",
     "wof:parent_id":1125325879,
     "wof:placetype":"locality",

--- a/data/112/577/445/3/1125774453.geojson
+++ b/data/112/577/445/3/1125774453.geojson
@@ -54,6 +54,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Groussbus"
     ],
+    "name:ltz_x_variant":[
+        "Groussbus"
+    ],
     "name:msa_x_preferred":[
         "Grosbous"
     ],
@@ -84,8 +87,14 @@
     "name:swe_x_preferred":[
         "Grosbous"
     ],
+    "name:tur_x_preferred":[
+        "Grosbous"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u0440\u043e\u0441\u0431\u0443\u0441"
+    ],
+    "name:zho_x_preferred":[
+        "\u683c\u7f57\u65af\u5e03\u65af"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -156,7 +165,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732178,
+    "wof:lastmodified":1690938775,
     "wof:name":"Grosbous",
     "wof:parent_id":1125284431,
     "wof:placetype":"locality",

--- a/data/112/577/676/1/1125776761.geojson
+++ b/data/112/577/676/1/1125776761.geojson
@@ -48,6 +48,9 @@
     "name:fra_x_preferred":[
         "Esch-sur-S\u00fbre"
     ],
+    "name:fur_x_preferred":[
+        "Esch-sur-S\u00fbre"
+    ],
     "name:gsw_x_preferred":[
         "Esch-Sauer"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng Esch-Sauer"
+    ],
+    "name:ltz_x_variant":[
+        "Esch-Sauer"
     ],
     "name:msa_x_preferred":[
         "Esch-sur-S\u00fbre"
@@ -90,11 +96,17 @@
     "name:swe_x_preferred":[
         "Esch-sur-S\u00fbre"
     ],
+    "name:tur_x_preferred":[
+        "Esch-sur-S\u00fbre"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u0448-\u0441\u044e\u0440-\u0421\u0443\u0440"
     ],
     "name:und_x_variant":[
         "Esch"
+    ],
+    "name:zho_x_preferred":[
+        "\u53d9\u5c14\u6cb3\u7554\u57c3\u65bd"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -165,7 +177,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732180,
+    "wof:lastmodified":1690938775,
     "wof:name":"Esch-sur-S\u00fbre",
     "wof:parent_id":1125333105,
     "wof:placetype":"locality",

--- a/data/112/577/782/3/1125777823.geojson
+++ b/data/112/577/782/3/1125777823.geojson
@@ -57,10 +57,16 @@
     "name:gsw_x_preferred":[
         "Stengefort"
     ],
+    "name:heb_x_preferred":[
+        "\u05e9\u05d8\u05d9\u05d9\u05e0\u05e4\u05d5\u05e8\u05d8"
+    ],
     "name:hun_x_preferred":[
         "Steinfort"
     ],
     "name:ita_x_preferred":[
+        "Steinfort"
+    ],
+    "name:lim_x_preferred":[
         "Steinfort"
     ],
     "name:lit_x_preferred":[
@@ -93,6 +99,9 @@
     "name:por_x_preferred":[
         "Steinfort"
     ],
+    "name:pus_x_preferred":[
+        "\u0633\u067c\u064a\u0646\u062c\u0641\u0648\u0631\u067c"
+    ],
     "name:rus_x_preferred":[
         "\u0428\u0442\u0435\u0439\u043d\u0444\u043e\u0440\u0442"
     ],
@@ -105,8 +114,14 @@
     "name:swe_x_preferred":[
         "Steinfort"
     ],
+    "name:tur_x_preferred":[
+        "Steinfort"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0442\u0430\u0439\u043d\u0444\u043e\u0440\u0442"
+    ],
+    "name:zho_x_preferred":[
+        "\u65bd\u6cf0\u56e0\u798f\u7279"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -177,7 +192,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732181,
+    "wof:lastmodified":1690938775,
     "wof:name":"Steinfort",
     "wof:parent_id":1125346159,
     "wof:placetype":"locality",

--- a/data/112/578/107/1/1125781071.geojson
+++ b/data/112/578/107/1/1125781071.geojson
@@ -48,6 +48,9 @@
     "name:fra_x_preferred":[
         "Biwer"
     ],
+    "name:fur_x_preferred":[
+        "Biwer"
+    ],
     "name:gsw_x_preferred":[
         "Biwer"
     ],
@@ -90,8 +93,14 @@
     "name:swe_x_preferred":[
         "Biwer"
     ],
+    "name:tur_x_preferred":[
+        "Biwer"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0456\u0432\u0435\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u6bd4\u97e6\u5c14"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -158,7 +167,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732182,
+    "wof:lastmodified":1690938774,
     "wof:name":"Biwer",
     "wof:parent_id":1125294519,
     "wof:placetype":"locality",

--- a/data/112/579/664/1/1125796641.geojson
+++ b/data/112/579/664/1/1125796641.geojson
@@ -60,11 +60,17 @@
     "name:jpn_x_preferred":[
         "\u30d0\u30c3\u30b7\u30e5\u30eb\u30a4\u30fc\u30c9\u30f3"
     ],
+    "name:kor_x_preferred":[
+        "\ubc14\uc6b0\uc178\ud2b8"
+    ],
     "name:lat_x_preferred":[
         "Bauschelt"
     ],
     "name:ltz_x_preferred":[
         "Gemeng Bauschelt"
+    ],
+    "name:ltz_x_variant":[
+        "Bauschelt"
     ],
     "name:msa_x_preferred":[
         "Boulaide"
@@ -96,8 +102,14 @@
     "name:swe_x_preferred":[
         "Boulaide"
     ],
+    "name:tur_x_preferred":[
+        "Boulaide"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0443\u043b\u0435\u0434"
+    ],
+    "name:zho_x_preferred":[
+        "\u5e03\u83b1\u5fb7"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -168,7 +180,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732184,
+    "wof:lastmodified":1690938774,
     "wof:name":"Boulaide",
     "wof:parent_id":1125366297,
     "wof:placetype":"locality",

--- a/data/112/579/918/7/1125799187.geojson
+++ b/data/112/579/918/7/1125799187.geojson
@@ -96,6 +96,9 @@
     "name:swe_x_preferred":[
         "Reisdorf"
     ],
+    "name:tur_x_preferred":[
+        "Reisdorf"
+    ],
     "name:ukr_x_preferred":[
         "\u0420\u0430\u0439\u0441\u0434\u043e\u0440\u0444"
     ],
@@ -171,7 +174,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732185,
+    "wof:lastmodified":1690938774,
     "wof:name":"Reisdorf",
     "wof:parent_id":1125285897,
     "wof:placetype":"locality",

--- a/data/112/580/029/7/1125800297.geojson
+++ b/data/112/580/029/7/1125800297.geojson
@@ -30,6 +30,9 @@
     "name:ceb_x_preferred":[
         "Weiswampach"
     ],
+    "name:chv_x_preferred":[
+        "\u0412\u0435\u0439\u0441\u0432\u0430\u043c\u043f\u0430\u0445"
+    ],
     "name:dan_x_preferred":[
         "Weiswampach"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng W\u00e4isswampech"
+    ],
+    "name:ltz_x_variant":[
+        "W\u00e4iswampech"
     ],
     "name:msa_x_preferred":[
         "Weiswampach"
@@ -87,8 +93,14 @@
     "name:swe_x_preferred":[
         "Weiswampach"
     ],
+    "name:tur_x_preferred":[
+        "Weiswampach"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u0439\u0441\u0432\u0430\u043c\u043f\u0430\u0445"
+    ],
+    "name:zho_x_preferred":[
+        "\u9b4f\u65af\u4e07\u5e15\u8d6b"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -159,7 +171,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732186,
+    "wof:lastmodified":1690938769,
     "wof:name":"Weiswampach",
     "wof:parent_id":1125352025,
     "wof:placetype":"locality",

--- a/data/112/580/921/5/1125809215.geojson
+++ b/data/112/580/921/5/1125809215.geojson
@@ -51,8 +51,14 @@
     "name:ita_x_preferred":[
         "Waldbillig"
     ],
+    "name:lim_x_preferred":[
+        "Waldbillig"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Waldb\u00eblleg"
+    ],
+    "name:ltz_x_variant":[
+        "Waldb\u00eblleg"
     ],
     "name:msa_x_preferred":[
         "Waldbillig"
@@ -87,11 +93,17 @@
     "name:tat_x_preferred":[
         "\u0412\u0430\u043b\u044c\u0434\u0431\u0438\u043b\u043b\u0438\u0433"
     ],
+    "name:tur_x_preferred":[
+        "Waldbillig"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u043b\u044c\u0434\u0431\u0456\u043b\u043b\u0456\u0433"
     ],
     "name:urd_x_preferred":[
         "\u0648\u0627\u0644\u062f\u0628\u06cc\u0644\u06af"
+    ],
+    "name:zho_x_preferred":[
+        "\u74e6\u5c14\u5fb7\u6bd4\u5229\u5e0c"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -162,7 +174,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732188,
+    "wof:lastmodified":1690938770,
     "wof:name":"Waldbillig",
     "wof:parent_id":1125305359,
     "wof:placetype":"locality",

--- a/data/112/581/187/3/1125811873.geojson
+++ b/data/112/581/187/3/1125811873.geojson
@@ -63,11 +63,17 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30ed\u30ef\u30f4\u30a3\u30a8\u30eb\u30b8\u30e5"
     ],
+    "name:kor_x_preferred":[
+        "\ud2b8\ub8e8\uc544\ube44\uc5d0\ub974\uc8fc"
+    ],
     "name:lim_x_preferred":[
         "Troisvierges"
     ],
     "name:ltz_x_preferred":[
         "Gemeng \u00cblwen"
+    ],
+    "name:ltz_x_variant":[
+        "\u00cblwen"
     ],
     "name:msa_x_preferred":[
         "Troisvierges"
@@ -108,11 +114,17 @@
     "name:swe_x_preferred":[
         "Troisvierges"
     ],
+    "name:tur_x_preferred":[
+        "Troisvierges"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0440\u0443\u0430\u0432\u0454\u0440\u0436"
     ],
     "name:ukr_x_variant":[
         "\u0422\u0440\u0443\u0430\u0432'\u0454\u0440\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u7279\u9c81\u74e6\u7ef4\u8036\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -183,7 +195,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732189,
+    "wof:lastmodified":1690938769,
     "wof:name":"Troisvierges",
     "wof:parent_id":1125352097,
     "wof:placetype":"locality",

--- a/data/112/586/156/9/1125861569.geojson
+++ b/data/112/586/156/9/1125861569.geojson
@@ -90,8 +90,14 @@
     "name:swe_x_preferred":[
         "Wahl"
     ],
+    "name:tur_x_preferred":[
+        "Wahl"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u043b\u044c"
+    ],
+    "name:zho_x_preferred":[
+        "\u74e6\u5c14"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -158,7 +164,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732190,
+    "wof:lastmodified":1690938768,
     "wof:name":"Wahl",
     "wof:parent_id":1125306043,
     "wof:placetype":"locality",

--- a/data/112/588/214/7/1125882147.geojson
+++ b/data/112/588/214/7/1125882147.geojson
@@ -54,6 +54,9 @@
     "name:ltz_x_preferred":[
         "Gemeng G\u00e9isdref"
     ],
+    "name:ltz_x_variant":[
+        "G\u00e9isdref"
+    ],
     "name:msa_x_preferred":[
         "Goesdorf"
     ],
@@ -84,11 +87,17 @@
     "name:swe_x_preferred":[
         "G\u0153sdorf"
     ],
+    "name:tur_x_preferred":[
+        "Goesdorf"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u0435\u0441\u0434\u043e\u0440\u0444"
     ],
     "name:und_x_variant":[
         "G\u00f6sdorf bei Wilz"
+    ],
+    "name:zho_x_preferred":[
+        "\u683c\u65af\u591a\u592b"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -159,7 +168,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732193,
+    "wof:lastmodified":1690938769,
     "wof:name":"Goesdorf",
     "wof:parent_id":1125298213,
     "wof:placetype":"locality",

--- a/data/112/592/146/7/1125921467.geojson
+++ b/data/112/592/146/7/1125921467.geojson
@@ -54,6 +54,9 @@
     "name:ita_x_preferred":[
         "Bech"
     ],
+    "name:lim_x_preferred":[
+        "Bech"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Bech"
     ],
@@ -88,6 +91,9 @@
         "Bech"
     ],
     "name:swe_x_preferred":[
+        "Bech"
+    ],
+    "name:tur_x_preferred":[
         "Bech"
     ],
     "name:ukr_x_preferred":[
@@ -165,7 +171,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1642551806,
+    "wof:lastmodified":1690938766,
     "wof:name":"Bech",
     "wof:parent_id":1125328045,
     "wof:placetype":"locality",

--- a/data/112/594/792/7/1125947927.geojson
+++ b/data/112/594/792/7/1125947927.geojson
@@ -60,6 +60,9 @@
     "name:ltz_x_preferred":[
         "Gemeng R\u00e9iser"
     ],
+    "name:ltz_x_variant":[
+        "R\u00e9iser"
+    ],
     "name:msa_x_preferred":[
         "Roeser"
     ],
@@ -78,6 +81,9 @@
     "name:por_x_preferred":[
         "Roeser"
     ],
+    "name:pus_x_preferred":[
+        "\u0631\u0648\u0632\u0631"
+    ],
     "name:rus_x_preferred":[
         "\u0420\u0435\u0437\u0435\u0440"
     ],
@@ -85,6 +91,9 @@
         "Roeser"
     ],
     "name:swe_x_preferred":[
+        "Roeser"
+    ],
+    "name:tur_x_preferred":[
         "Roeser"
     ],
     "name:ukr_x_preferred":[
@@ -159,7 +168,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732198,
+    "wof:lastmodified":1690938765,
     "wof:name":"Roeser",
     "wof:parent_id":1125324091,
     "wof:placetype":"locality",

--- a/data/112/595/236/5/1125952365.geojson
+++ b/data/112/595/236/5/1125952365.geojson
@@ -87,8 +87,14 @@
     "name:swe_x_preferred":[
         "Tandel"
     ],
+    "name:tur_x_preferred":[
+        "Tandel"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u043d\u0434\u0435\u043b\u044c"
+    ],
+    "name:zho_x_preferred":[
+        "\u5766\u5fb7\u5c14"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -155,7 +161,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732200,
+    "wof:lastmodified":1690938767,
     "wof:name":"Tandel",
     "wof:parent_id":1745980851,
     "wof:placetype":"locality",

--- a/data/112/595/737/3/1125957373.geojson
+++ b/data/112/595/737/3/1125957373.geojson
@@ -87,6 +87,9 @@
     "name:por_x_preferred":[
         "Hesperange"
     ],
+    "name:pus_x_preferred":[
+        "\u0633\u067e\u0631\u0627\u0646\u0698"
+    ],
     "name:ron_x_preferred":[
         "Hesperange"
     ],
@@ -105,8 +108,14 @@
     "name:swe_x_preferred":[
         "Hesperange"
     ],
+    "name:tur_x_preferred":[
+        "Hesperange"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u0441\u043f\u0435\u0440\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u57c3\u65af\u73c0\u6717\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -177,7 +186,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732201,
+    "wof:lastmodified":1690938766,
     "wof:name":"Hesperange",
     "wof:parent_id":1125305925,
     "wof:placetype":"locality",

--- a/data/112/595/877/7/1125958777.geojson
+++ b/data/112/595/877/7/1125958777.geojson
@@ -87,8 +87,14 @@
     "name:swe_x_preferred":[
         "Vichten"
     ],
+    "name:tur_x_preferred":[
+        "Vichten"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0456\u0445\u0442\u0435\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u7ef4\u5e0c\u6ed5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -157,7 +163,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732202,
+    "wof:lastmodified":1690938766,
     "wof:name":"Vichten",
     "wof:parent_id":1745980837,
     "wof:placetype":"locality",

--- a/data/112/598/427/9/1125984279.geojson
+++ b/data/112/598/427/9/1125984279.geojson
@@ -30,6 +30,9 @@
     "name:ceb_x_preferred":[
         "Nommern"
     ],
+    "name:ces_x_preferred":[
+        "Nommern"
+    ],
     "name:dan_x_preferred":[
         "Nommern"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ltz_x_preferred":[
         "Gemeng Noumer"
+    ],
+    "name:ltz_x_variant":[
+        "Noumer"
     ],
     "name:msa_x_preferred":[
         "Nommern"
@@ -85,6 +91,9 @@
         "Nommern"
     ],
     "name:swe_x_preferred":[
+        "Nommern"
+    ],
+    "name:tur_x_preferred":[
         "Nommern"
     ],
     "name:ukr_x_preferred":[
@@ -159,7 +168,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732204,
+    "wof:lastmodified":1690938771,
     "wof:name":"Nommern",
     "wof:parent_id":1125284735,
     "wof:placetype":"locality",

--- a/data/112/599/064/1/1125990641.geojson
+++ b/data/112/599/064/1/1125990641.geojson
@@ -54,8 +54,14 @@
     "name:ita_x_preferred":[
         "Lorentzweiler"
     ],
+    "name:lit_x_preferred":[
+        "Lorencvaileris"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Luerenzweiler"
+    ],
+    "name:ltz_x_variant":[
+        "Luerenzweiler"
     ],
     "name:msa_x_preferred":[
         "Lorentzweiler"
@@ -87,11 +93,17 @@
     "name:swe_x_preferred":[
         "Lorentzweiler"
     ],
+    "name:tur_x_preferred":[
+        "Lorentzweiler"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u043e\u0440\u0435\u043d\u0446\u0432\u0430\u0439\u043b\u0435\u0440"
     ],
     "name:und_x_variant":[
         "Lorenzweiler"
+    ],
+    "name:zho_x_preferred":[
+        "\u6d1b\u4f26\u8328\u97e6\u52d2"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -162,7 +174,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732205,
+    "wof:lastmodified":1690938770,
     "wof:name":"Lorentzweiler",
     "wof:parent_id":1125366377,
     "wof:placetype":"locality",

--- a/data/112/600/705/7/1126007057.geojson
+++ b/data/112/600/705/7/1126007057.geojson
@@ -57,6 +57,9 @@
     "name:ita_x_preferred":[
         "Sanem"
     ],
+    "name:kor_x_preferred":[
+        "\uc8fc\uc5d0\uc148"
+    ],
     "name:lit_x_preferred":[
         "Sanemas"
     ],
@@ -93,8 +96,14 @@
     "name:swe_x_preferred":[
         "Sanem"
     ],
+    "name:tur_x_preferred":[
+        "Sanem"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043d\u0435\u043c"
+    ],
+    "name:zho_x_preferred":[
+        "\u8428\u5185\u59c6"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -165,7 +174,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732206,
+    "wof:lastmodified":1690938773,
     "wof:name":"Sanem",
     "wof:parent_id":1125299915,
     "wof:placetype":"locality",

--- a/data/112/600/706/3/1126007063.geojson
+++ b/data/112/600/706/3/1126007063.geojson
@@ -72,6 +72,9 @@
     "name:mkd_x_preferred":[
         "\u0421\u0430\u043d\u0434\u0432\u0435\u0458\u043b\u0435\u0440"
     ],
+    "name:mlt_x_preferred":[
+        "Sandweiler"
+    ],
     "name:msa_x_preferred":[
         "Sandweiler"
     ],
@@ -102,8 +105,14 @@
     "name:swe_x_preferred":[
         "Sandweiler"
     ],
+    "name:tur_x_preferred":[
+        "Sandweiler"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043d\u0434\u0432\u0430\u0439\u043b\u0435\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u6851\u5fb7\u97e6\u52d2"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -174,7 +183,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732208,
+    "wof:lastmodified":1690938772,
     "wof:name":"Sandweiler",
     "wof:parent_id":1125366287,
     "wof:placetype":"locality",

--- a/data/112/600/859/7/1126008597.geojson
+++ b/data/112/600/859/7/1126008597.geojson
@@ -54,6 +54,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Hiefenech"
     ],
+    "name:ltz_x_variant":[
+        "Hiefenech"
+    ],
     "name:msa_x_preferred":[
         "Heffingen"
     ],
@@ -84,8 +87,17 @@
     "name:swe_x_preferred":[
         "Heffingen"
     ],
+    "name:tur_x_preferred":[
+        "Heffingen"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u0435\u0444\u0444\u0456\u043d\u0433\u0435\u043d"
+    ],
+    "name:ukr_x_variant":[
+        "\u0413\u0435\u0444\u0444\u0456\u043d\u0491\u0435\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ed1\u82ac\u6839"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -156,7 +168,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732209,
+    "wof:lastmodified":1690938773,
     "wof:name":"Heffingen",
     "wof:parent_id":1125288903,
     "wof:placetype":"locality",

--- a/data/112/601/545/3/1126015453.geojson
+++ b/data/112/601/545/3/1126015453.geojson
@@ -57,6 +57,9 @@
     "name:ita_x_preferred":[
         "Schifflange"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30d5\u30d5\u30e9\u30f3\u30b8\u30e5"
+    ],
     "name:lit_x_preferred":[
         "\u0160iflan\u017eas"
     ],
@@ -99,8 +102,14 @@
     "name:swe_x_preferred":[
         "Schifflange"
     ],
+    "name:tur_x_preferred":[
+        "Schifflange"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0438\u0444\u0444\u043b\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u5e0c\u592b\u6717\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -171,7 +180,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732210,
+    "wof:lastmodified":1690938772,
     "wof:name":"Schifflange",
     "wof:parent_id":1745980861,
     "wof:placetype":"locality",

--- a/data/112/601/930/5/1126019305.geojson
+++ b/data/112/601/930/5/1126019305.geojson
@@ -66,6 +66,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Schieren"
     ],
+    "name:ltz_x_variant":[
+        "Schieren"
+    ],
     "name:msa_x_preferred":[
         "Schieren"
     ],
@@ -174,7 +177,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732212,
+    "wof:lastmodified":1690938771,
     "wof:name":"Schieren",
     "wof:parent_id":1745980829,
     "wof:placetype":"locality",

--- a/data/112/601/979/3/1126019793.geojson
+++ b/data/112/601/979/3/1126019793.geojson
@@ -87,8 +87,14 @@
     "name:swe_x_preferred":[
         "Saeul"
     ],
+    "name:tur_x_preferred":[
+        "Saeul"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u044e\u043b\u044c"
+    ],
+    "name:zho_x_preferred":[
+        "\u7d22\u4f0a\u5c14"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -157,7 +163,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732213,
+    "wof:lastmodified":1690938772,
     "wof:name":"Saeul",
     "wof:parent_id":1745980831,
     "wof:placetype":"locality",

--- a/data/112/602/565/3/1126025653.geojson
+++ b/data/112/602/565/3/1126025653.geojson
@@ -60,6 +60,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Wanseler"
     ],
+    "name:ltz_x_variant":[
+        "Wanseler"
+    ],
     "name:msa_x_preferred":[
         "Winseler"
     ],
@@ -78,6 +81,9 @@
     "name:por_x_preferred":[
         "Winseler"
     ],
+    "name:pus_x_preferred":[
+        "\u0648\u064a\u0646\u0632\u0644\u0631"
+    ],
     "name:rus_x_preferred":[
         "\u0412\u0438\u043d\u0437\u0435\u043b\u0435\u0440"
     ],
@@ -90,8 +96,14 @@
     "name:swe_x_preferred":[
         "Winseler"
     ],
+    "name:tur_x_preferred":[
+        "Winseler"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0456\u043d\u0441\u0435\u043b\u0435\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u6e29\u745f\u52d2"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -160,7 +172,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732214,
+    "wof:lastmodified":1690938767,
     "wof:name":"Winseler",
     "wof:parent_id":1125284497,
     "wof:placetype":"locality",

--- a/data/112/603/770/7/1126037707.geojson
+++ b/data/112/603/770/7/1126037707.geojson
@@ -54,6 +54,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Stadbriedemes"
     ],
+    "name:ltz_x_variant":[
+        "Stadbriedemes"
+    ],
     "name:msa_x_preferred":[
         "Stadtbredimus"
     ],
@@ -84,8 +87,14 @@
     "name:swe_x_preferred":[
         "Stadtbredimus"
     ],
+    "name:tur_x_preferred":[
+        "Stadtbredimus"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0442\u0430\u0434\u0442\u0431\u0440\u0435\u0434\u0456\u043c\u044e"
+    ],
+    "name:zho_x_preferred":[
+        "\u65bd\u5854\u7279\u5e03\u96f7\u8fea\u7a46\u65af"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -156,7 +165,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626732217,
+    "wof:lastmodified":1690938768,
     "wof:name":"Stadtbredimus",
     "wof:parent_id":1125341017,
     "wof:placetype":"locality",

--- a/data/112/606/815/1/1126068151.geojson
+++ b/data/112/606/815/1/1126068151.geojson
@@ -42,6 +42,9 @@
     "name:nld_x_preferred":[
         "Weimerskirch"
     ],
+    "name:spa_x_preferred":[
+        "Weimerskirch"
+    ],
     "name:swe_x_preferred":[
         "Weimerskirch"
     ],
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -105,7 +108,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733543,
+    "wof:lastmodified":1690938771,
     "wof:name":"Weimerskirch",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/751/7/1126097517.geojson
+++ b/data/112/609/751/7/1126097517.geojson
@@ -44,6 +44,12 @@
     "name:nld_x_preferred":[
         "Eich"
     ],
+    "name:rus_x_preferred":[
+        "\u0410\u0439\u0445"
+    ],
+    "name:spa_x_preferred":[
+        "Eich"
+    ],
     "name:swe_x_preferred":[
         "Eich"
     ],
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733546,
+    "wof:lastmodified":1690938773,
     "wof:name":"Eich",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/664/5/1745986645.geojson
+++ b/data/174/598/664/5/1745986645.geojson
@@ -19,10 +19,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ast_x_preferred":[
+        "Berg"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u0435\u0440\u0433"
     ],
     "name:cat_x_preferred":[
+        "Berg"
+    ],
+    "name:ces_x_preferred":[
+        "Berg"
+    ],
+    "name:deu_x_preferred":[
         "Berg"
     ],
     "name:eng_x_preferred":[
@@ -46,6 +55,9 @@
     "name:nld_x_preferred":[
         "Berg"
     ],
+    "name:swe_x_preferred":[
+        "Berg"
+    ],
     "qs:a0":"Luxembourg",
     "qs:a1":"*",
     "qs:a1r":"0",
@@ -67,11 +79,11 @@
     "wd:longitude":6.35,
     "wd:wordcount":52,
     "wof:belongsto":[
-        1745977439,
         102191581,
         1745980835,
         85633275,
-        1745984171
+        1745984171,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,7 +124,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733063,
+    "wof:lastmodified":1690938731,
     "wof:name":"Berg",
     "wof:parent_id":1745984171,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/666/5/1745986665.geojson
+++ b/data/174/598/666/5/1745986665.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Schoenfels"
+    ],
     "name:cat_x_preferred":[
         "Schoenfels"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125286143,
         85633275,
-        101812883
+        101812883,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733074,
+    "wof:lastmodified":1690938713,
     "wof:name":"Schoenfels",
     "wof:parent_id":101812883,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/667/3/1745986673.geojson
+++ b/data/174/598/667/3/1745986673.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Kockelscheuer"
+    ],
     "name:cat_x_preferred":[
         "Kockelscheuer"
     ],
@@ -51,6 +54,9 @@
     "name:pol_x_preferred":[
         "Kockelscheuer"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043a\u0435\u043b\u044c\u0448\u043e\u0439\u0435\u0440"
+    ],
     "name:swe_x_preferred":[
         "Kockelscheuer"
     ],
@@ -80,11 +86,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125324091,
         85633275,
-        1125947927
+        1125947927,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,7 +123,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733077,
+    "wof:lastmodified":1690938711,
     "wof:name":"Kockelscheuer",
     "wof:parent_id":1125947927,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/667/5/1745986675.geojson
+++ b/data/174/598/667/5/1745986675.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Ospern"
+    ],
     "name:cat_x_preferred":[
         "Ospern"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125402395,
         85633275,
-        101845561
+        101845561,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733078,
+    "wof:lastmodified":1690938711,
     "wof:name":"Ospern",
     "wof:parent_id":101845561,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/667/7/1745986677.geojson
+++ b/data/174/598/667/7/1745986677.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Rippweiler"
+    ],
     "name:cat_x_preferred":[
         "Rippweiler"
     ],
@@ -34,6 +37,9 @@
         "Rippweiler"
     ],
     "name:fra_x_preferred":[
+        "Rippweiler"
+    ],
+    "name:hun_x_preferred":[
         "Rippweiler"
     ],
     "name:ltz_x_preferred":[
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125366387,
         85633275,
-        101812881
+        101812881,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733080,
+    "wof:lastmodified":1690938711,
     "wof:name":"Rippweiler",
     "wof:parent_id":101812881,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/668/3/1745986683.geojson
+++ b/data/174/598/668/3/1745986683.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0644\u0627\u0633\u0648\u0641\u0627\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0633\u0648\u0641\u0627\u062c"
+    ],
     "name:cat_x_preferred":[
         "Lasauvage"
     ],
@@ -49,6 +52,9 @@
     "name:swe_x_preferred":[
         "Lasauvage"
     ],
+    "name:szl_x_preferred":[
+        "Lasauvage"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:name":"Lasauvage",
@@ -73,11 +79,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125280445,
         85633275,
-        101839817
+        101839817,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733083,
+    "wof:lastmodified":1690938714,
     "wof:name":"Lasauvage",
     "wof:parent_id":101839817,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/669/1/1745986691.geojson
+++ b/data/174/598/669/1/1745986691.geojson
@@ -54,6 +54,9 @@
     "name:swe_x_preferred":[
         "Neihaischen"
     ],
+    "name:ukr_x_preferred":[
+        "\u041d\u044e\u043d\u0445\u0430\u0443\u0437\u0433\u0435\u043d"
+    ],
     "name:und_x_variant":[
         "Neuhaeusgen"
     ],
@@ -81,11 +84,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125375263,
         85633275,
-        101812899
+        101812899,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -118,7 +121,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733087,
+    "wof:lastmodified":1690938709,
     "wof:name":"Neihaischen",
     "wof:parent_id":101812899,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/669/3/1745986693.geojson
+++ b/data/174/598/669/3/1745986693.geojson
@@ -57,8 +57,14 @@
     "name:ita_x_preferred":[
         "Ell"
     ],
+    "name:lit_x_preferred":[
+        "Elis"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Ell"
+    ],
+    "name:ltz_x_variant":[
+        "Ell"
     ],
     "name:msa_x_preferred":[
         "Ell"
@@ -93,8 +99,14 @@
     "name:swe_x_preferred":[
         "Ell"
     ],
+    "name:tur_x_preferred":[
+        "Ell"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u043b\u044c"
+    ],
+    "name:zho_x_preferred":[
+        "\u57c3\u5c14"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -122,11 +134,11 @@
     "woe:name_adm1":"Rheinland-Pfalz",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125306051,
         85633275,
-        1745984173
+        1745984173,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -159,7 +171,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733088,
+    "wof:lastmodified":1690938709,
     "wof:name":"Fell",
     "wof:parent_id":1745984173,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/669/5/1745986695.geojson
+++ b/data/174/598/669/5/1745986695.geojson
@@ -21,11 +21,17 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Wilwerdange"
+    ],
     "name:cat_x_preferred":[
         "Wilwerdange"
     ],
     "name:ceb_x_preferred":[
         "Wilwerdange"
+    ],
+    "name:deu_x_preferred":[
+        "Wilwerdingen"
     ],
     "name:eng_x_preferred":[
         "Wilwerdange"
@@ -77,11 +83,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125352097,
         85633275,
-        1125811873
+        1125811873,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733089,
+    "wof:lastmodified":1690938709,
     "wof:name":"Wilwerdange",
     "wof:parent_id":1125811873,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/670/3/1745986703.geojson
+++ b/data/174/598/670/3/1745986703.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Ehlerange"
+    ],
     "name:cat_x_preferred":[
         "Ehlerange"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125299915,
         85633275,
-        1126007057
+        1126007057,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733094,
+    "wof:lastmodified":1690938729,
     "wof:name":"Ehlerange",
     "wof:parent_id":1126007057,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/670/9/1745986709.geojson
+++ b/data/174/598/670/9/1745986709.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Crauthem"
+    ],
     "name:cat_x_preferred":[
         "Crauthem"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125324091,
         85633275,
-        1125947927
+        1125947927,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733096,
+    "wof:lastmodified":1690938728,
     "wof:name":"Crauthem",
     "wof:parent_id":1125947927,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/671/3/1745986713.geojson
+++ b/data/174/598/671/3/1745986713.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0644\u0631\u062b\u0627\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0644\u0631\u062b\u0627\u0644"
+    ],
     "name:cat_x_preferred":[
         "Mullerthal"
     ],
@@ -91,11 +94,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977445,
         102191581,
         1125285639,
         85633275,
-        101812879
+        101812879,
+        1745977445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -128,7 +131,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733098,
+    "wof:lastmodified":1690938727,
     "wof:name":"M\u00fcllerthal",
     "wof:parent_id":101812879,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/671/5/1745986715.geojson
+++ b/data/174/598/671/5/1745986715.geojson
@@ -36,6 +36,9 @@
     "name:ltz_x_preferred":[
         "Iischpelt"
     ],
+    "name:ltz_x_variant":[
+        "Eeschpelt"
+    ],
     "name:nld_x_preferred":[
         "Tarchamps"
     ],
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125283425,
         85633275,
-        1126028027
+        1126028027,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733099,
+    "wof:lastmodified":1690938727,
     "wof:name":"Tarchamps",
     "wof:parent_id":1126028027,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/672/1/1745986721.geojson
+++ b/data/174/598/672/1/1745986721.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Capellen"
     ],
+    "name:deu_x_preferred":[
+        "Capellen"
+    ],
     "name:eng_x_preferred":[
         "Capellen"
     ],
@@ -36,8 +39,14 @@
     "name:hun_x_preferred":[
         "Capellen"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30da\u30ec\u30f3"
+    ],
     "name:ltz_x_preferred":[
         "Kapellen"
+    ],
+    "name:ltz_x_variant":[
+        "Capellen"
     ],
     "name:nld_x_preferred":[
         "Capellen"
@@ -54,6 +63,15 @@
     "name:swe_x_preferred":[
         "Capellen"
     ],
+    "name:tha_x_preferred":[
+        "\u0e04\u0e32\u0e41\u0e1e\u0e47\u0e25\u0e40\u0e25\u0e34\u0e19"
+    ],
+    "name:tur_x_preferred":[
+        "Capellen"
+    ],
+    "name:zho_x_preferred":[
+        "\u5361\u4f69\u4f26"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -69,11 +87,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125305791,
         85633275,
-        101753077
+        101753077,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -105,7 +123,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733103,
+    "wof:lastmodified":1690938703,
     "wof:name":"Capellen",
     "wof:parent_id":101753077,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/672/3/1745986723.geojson
+++ b/data/174/598/672/3/1745986723.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Greiveldange"
     ],
+    "name:deu_x_preferred":[
+        "Greiweldingen"
+    ],
     "name:eng_x_preferred":[
         "Greiveldange"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1125341017,
         85633275,
-        1126037707
+        1126037707,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733104,
+    "wof:lastmodified":1690938703,
     "wof:name":"Greiveldange",
     "wof:parent_id":1126037707,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/673/1/1745986731.geojson
+++ b/data/174/598/673/1/1745986731.geojson
@@ -21,8 +21,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Rodershausen"
+    ],
     "name:ceb_x_preferred":[
         "Rodershausen"
+    ],
+    "name:che_x_preferred":[
+        "\u0420\u043e\u0434\u0435\u0440\u0441\u0445\u0430\u0443\u0437\u0435\u043d"
     ],
     "name:deu_x_preferred":[
         "Rodershausen"
@@ -57,10 +63,19 @@
     "name:kir_x_preferred":[
         "\u0420\u043e\u0434\u0435\u0440\u0441\u0445\u0430\u0443\u0437\u0435\u043d"
     ],
+    "name:kur_x_preferred":[
+        "Rodershausen"
+    ],
     "name:msa_x_preferred":[
         "Rodershausen"
     ],
+    "name:nan_x_preferred":[
+        "Rodershausen"
+    ],
     "name:nld_x_preferred":[
+        "Rodershausen"
+    ],
+    "name:nob_x_preferred":[
         "Rodershausen"
     ],
     "name:pol_x_preferred":[
@@ -79,6 +94,12 @@
         "Rodershausen"
     ],
     "name:srp_x_preferred":[
+        "\u0420\u043e\u0434\u0435\u0440\u0441\u0445\u0430\u0443\u0437\u0435\u043d"
+    ],
+    "name:swe_x_preferred":[
+        "Rodershausen"
+    ],
+    "name:tat_x_preferred":[
         "\u0420\u043e\u0434\u0435\u0440\u0441\u0445\u0430\u0443\u0437\u0435\u043d"
     ],
     "name:ukr_x_preferred":[
@@ -123,11 +144,11 @@
     "woe:name_adm1":"Rheinland-Pfalz",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125324097,
         85633275,
-        101845555
+        101845555,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -160,7 +181,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733108,
+    "wof:lastmodified":1690938707,
     "wof:name":"Rodershausen",
     "wof:parent_id":101845555,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/673/5/1745986735.geojson
+++ b/data/174/598/673/5/1745986735.geojson
@@ -30,6 +30,9 @@
     "name:eng_x_preferred":[
         "Platen"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0644\u0627\u062a\u06cc\u0646"
+    ],
     "name:fra_x_preferred":[
         "Platen"
     ],
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1745980841,
         85633275,
-        1745984183
+        1745984183,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733110,
+    "wof:lastmodified":1690938708,
     "wof:name":"Platen",
     "wof:parent_id":1745984183,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/673/9/1745986739.geojson
+++ b/data/174/598/673/9/1745986739.geojson
@@ -30,6 +30,9 @@
     "name:eng_x_preferred":[
         "Rodenbourg"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u0648\u062f\u0646\u0628\u0648\u0631\u06af"
+    ],
     "name:fra_x_preferred":[
         "Rodenbourg"
     ],
@@ -47,6 +50,9 @@
     ],
     "name:swe_x_preferred":[
         "Rodenbourg"
+    ],
+    "name:zho_x_preferred":[
+        "\u7f57\u5f53\u5821"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -72,11 +78,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125296455,
         85633275,
-        101812889
+        101812889,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733112,
+    "wof:lastmodified":1690938707,
     "wof:name":"Broderbour",
     "wof:parent_id":101812889,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/674/5/1745986745.geojson
+++ b/data/174/598/674/5/1745986745.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Roedgen"
     ],
+    "name:deu_x_preferred":[
+        "Roedgen"
+    ],
     "name:eng_x_preferred":[
         "Roedgen"
     ],
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1745980833,
         85633275,
-        1125880997
+        1125880997,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733115,
+    "wof:lastmodified":1690938707,
     "wof:name":"Roedgen",
     "wof:parent_id":1125880997,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/677/3/1745986773.geojson
+++ b/data/174/598/677/3/1745986773.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Moesdorf"
+    ],
     "name:cat_x_preferred":[
         "Moesdorf"
     ],
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125286143,
         85633275,
-        101812883
+        101812883,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733130,
+    "wof:lastmodified":1690938730,
     "wof:name":"Moesdorf",
     "wof:parent_id":101812883,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/678/1/1745986781.geojson
+++ b/data/174/598/678/1/1745986781.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Hovelange"
+    ],
     "name:cat_x_preferred":[
         "Hovelange"
     ],
@@ -72,11 +75,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125325865,
         85633275,
-        101845563
+        101845563,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733134,
+    "wof:lastmodified":1690938727,
     "wof:name":"Hovelange",
     "wof:parent_id":101845563,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/678/7/1745986787.geojson
+++ b/data/174/598/678/7/1745986787.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Rameldange"
+    ],
     "name:cat_x_preferred":[
         "Rameldange"
     ],
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125410759,
         85633275,
-        101753075
+        101753075,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733137,
+    "wof:lastmodified":1690938727,
     "wof:name":"Rammeldange",
     "wof:parent_id":101753075,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/679/3/1745986793.geojson
+++ b/data/174/598/679/3/1745986793.geojson
@@ -21,8 +21,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Rivenich"
+    ],
     "name:ceb_x_preferred":[
         "Rivenich"
+    ],
+    "name:che_x_preferred":[
+        "\u0420\u0438\u0432\u0435\u043d\u0438\u0445"
     ],
     "name:dan_x_preferred":[
         "Rivenich"
@@ -63,10 +69,22 @@
     "name:kir_x_preferred":[
         "\u0420\u0438\u0444\u0435\u043d\u0438\u0445"
     ],
+    "name:kur_x_preferred":[
+        "Rivenich"
+    ],
+    "name:ltz_x_preferred":[
+        "Rivenich"
+    ],
     "name:msa_x_preferred":[
         "Rivenich"
     ],
+    "name:nan_x_preferred":[
+        "Rivenich"
+    ],
     "name:nld_x_preferred":[
+        "Rivenich"
+    ],
+    "name:nob_x_preferred":[
         "Rivenich"
     ],
     "name:pol_x_preferred":[
@@ -89,6 +107,9 @@
     ],
     "name:swe_x_preferred":[
         "Rivenich"
+    ],
+    "name:tat_x_preferred":[
+        "\u0420\u0438\u0432\u0435\u043d\u0438\u0445"
     ],
     "name:ukr_x_preferred":[
         "\u0420\u0456\u0444\u0435\u043d\u0456\u0445"
@@ -135,11 +156,11 @@
     "woe:name_adm1":"Rheinland-Pfalz",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977445,
         102191581,
         1745980855,
         85633275,
-        1745984189
+        1745984189,
+        1745977445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -172,7 +193,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733141,
+    "wof:lastmodified":1690938728,
     "wof:name":"Rivenich",
     "wof:parent_id":1745984189,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/682/1/1745986821.geojson
+++ b/data/174/598/682/1/1745986821.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Lannen"
     ],
+    "name:deu_x_preferred":[
+        "Lannen"
+    ],
     "name:eng_x_preferred":[
         "Lannen"
     ],
@@ -75,11 +78,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125402395,
         85633275,
-        101845561
+        101845561,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733155,
+    "wof:lastmodified":1690938725,
     "wof:name":"Lannen",
     "wof:parent_id":101845561,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/682/5/1745986825.geojson
+++ b/data/174/598/682/5/1745986825.geojson
@@ -36,11 +36,17 @@
     "name:eng_x_preferred":[
         "Arsdorf"
     ],
+    "name:fas_x_preferred":[
+        "\u0622\u0631\u0633\u062f\u0648\u0631\u0641"
+    ],
     "name:fra_x_preferred":[
         "Arsdorf"
     ],
     "name:ltz_x_preferred":[
         "Uerschdref"
+    ],
+    "name:ltz_x_variant":[
+        "Ueschdref"
     ],
     "name:msa_x_preferred":[
         "Arsdorf"
@@ -66,11 +72,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125410765,
         85633275,
-        101812867
+        101812867,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +108,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733157,
+    "wof:lastmodified":1690938726,
     "wof:name":"Arsdorf",
     "wof:parent_id":101812867,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/683/9/1745986839.geojson
+++ b/data/174/598/683/9/1745986839.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Fouhren"
+    ],
     "name:bar_x_preferred":[
         "Fuhren"
     ],
@@ -54,6 +57,9 @@
     "name:swe_x_preferred":[
         "Fouhren"
     ],
+    "name:zho_x_preferred":[
+        "\u5bcc\u4f26"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -80,11 +86,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977449,
         102191581,
         1745980851,
         85633275,
-        1125952365
+        1125952365,
+        1745977449
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,7 +123,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733165,
+    "wof:lastmodified":1690938730,
     "wof:name":"Fouhren",
     "wof:parent_id":1125952365,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/684/1/1745986841.geojson
+++ b/data/174/598/684/1/1745986841.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Stegen"
+    ],
     "name:cat_x_preferred":[
         "Stegen"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977441,
         102191581,
         1745980859,
         85633275,
-        1745984191
+        1745984191,
+        1745977441
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733166,
+    "wof:lastmodified":1690938729,
     "wof:name":"Stegen",
     "wof:parent_id":1745984191,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/684/3/1745986843.geojson
+++ b/data/174/598/684/3/1745986843.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Bavigne"
+    ],
     "name:cat_x_preferred":[
         "Bavigne"
     ],
@@ -66,11 +69,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125283425,
         85633275,
-        1126028027
+        1126028027,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +105,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733167,
+    "wof:lastmodified":1690938729,
     "wof:name":"Bavigne",
     "wof:parent_id":1126028027,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/684/9/1745986849.geojson
+++ b/data/174/598/684/9/1745986849.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Scheidgen"
+    ],
     "name:cat_x_preferred":[
         "Scheidgen"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977445,
         102191581,
         1125285639,
         85633275,
-        101812879
+        101812879,
+        1745977445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733171,
+    "wof:lastmodified":1690938729,
     "wof:name":"Scheidgen",
     "wof:parent_id":101812879,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/685/5/1745986855.geojson
+++ b/data/174/598/685/5/1745986855.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Oberwampach"
     ],
+    "name:dan_x_preferred":[
+        "Oberwampach"
+    ],
     "name:deu_x_preferred":[
         "Oberwampach"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1745980853,
         85633275,
-        101811727
+        101811727,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733173,
+    "wof:lastmodified":1690938726,
     "wof:name":"Oberwampach",
     "wof:parent_id":101811727,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/685/7/1745986857.geojson
+++ b/data/174/598/685/7/1745986857.geojson
@@ -42,6 +42,9 @@
     "name:nld_x_preferred":[
         "Bergem"
     ],
+    "name:nob_x_preferred":[
+        "Bergem"
+    ],
     "name:pol_x_preferred":[
         "Bergem"
     ],
@@ -63,11 +66,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125293961,
         85633275,
-        101812915
+        101812915,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,7 +102,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733174,
+    "wof:lastmodified":1690938726,
     "wof:name":"Bergem",
     "wof:parent_id":101812915,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/686/3/1745986863.geojson
+++ b/data/174/598/686/3/1745986863.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Olingen"
+    ],
     "name:cat_x_preferred":[
         "Olingen"
     ],
     "name:ceb_x_preferred":[
+        "Olingen"
+    ],
+    "name:ces_x_preferred":[
         "Olingen"
     ],
     "name:eng_x_preferred":[
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125325873,
         85633275,
-        101854569
+        101854569,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733178,
+    "wof:lastmodified":1690938703,
     "wof:name":"Olingen",
     "wof:parent_id":101854569,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/686/5/1745986865.geojson
+++ b/data/174/598/686/5/1745986865.geojson
@@ -42,6 +42,9 @@
     "name:eng_x_preferred":[
         "Consthum"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0646\u0633\u062a\u0648\u0645"
+    ],
     "name:fra_x_preferred":[
         "Consthum"
     ],
@@ -84,6 +87,9 @@
     "name:swe_x_preferred":[
         "Consthum"
     ],
+    "name:tur_x_preferred":[
+        "Consthum"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043d\u0441\u0442\u0443\u043c"
     ],
@@ -113,11 +119,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125324097,
         85633275,
-        101845555
+        101845555,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -150,7 +156,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733179,
+    "wof:lastmodified":1690938703,
     "wof:name":"Konsthum",
     "wof:parent_id":101845555,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/688/3/1745986883.geojson
+++ b/data/174/598/688/3/1745986883.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Aspelt"
     ],
+    "name:dan_x_preferred":[
+        "Aspelt"
+    ],
     "name:deu_x_preferred":[
         "Aspelt"
     ],
@@ -47,6 +50,9 @@
     ],
     "name:swe_x_preferred":[
         "Aspelt"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u65af\u73c0\u723e\u7279"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -76,11 +82,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125410585,
         85633275,
-        101812919
+        101812919,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +119,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733189,
+    "wof:lastmodified":1690938704,
     "wof:name":"Aspelt",
     "wof:parent_id":101812919,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/688/5/1745986885.geojson
+++ b/data/174/598/688/5/1745986885.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Eischen"
+    ],
     "name:cat_x_preferred":[
         "Eischen"
     ],
@@ -79,11 +82,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125284213,
         85633275,
-        101845565
+        101845565,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,7 +119,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733190,
+    "wof:lastmodified":1690938704,
     "wof:name":"Eischen",
     "wof:parent_id":101845565,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/689/1/1745986891.geojson
+++ b/data/174/598/689/1/1745986891.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Bridel"
+    ],
     "name:cat_x_preferred":[
         "Bridel"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125286175,
         85633275,
-        101810571
+        101810571,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733192,
+    "wof:lastmodified":1690938705,
     "wof:name":"Bridel",
     "wof:parent_id":101810571,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/689/3/1745986893.geojson
+++ b/data/174/598/689/3/1745986893.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Bivange"
+    ],
     "name:cat_x_preferred":[
         "Bivange"
     ],
@@ -40,6 +43,9 @@
         "Bivange"
     ],
     "name:fra_x_preferred":[
+        "Bivange"
+    ],
+    "name:gle_x_preferred":[
         "Bivange"
     ],
     "name:ltz_x_preferred":[
@@ -83,11 +89,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125324091,
         85633275,
-        1125947927
+        1125947927,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,7 +126,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733193,
+    "wof:lastmodified":1690938705,
     "wof:name":"Bivange",
     "wof:parent_id":1125947927,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/689/9/1745986899.geojson
+++ b/data/174/598/689/9/1745986899.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Schwebsange"
+    ],
     "name:cat_x_preferred":[
         "Schwebsange"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1745980847,
         85633275,
-        1125883515
+        1125883515,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733197,
+    "wof:lastmodified":1690938705,
     "wof:name":"Schwebsingen",
     "wof:parent_id":1125883515,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/690/3/1745986903.geojson
+++ b/data/174/598/690/3/1745986903.geojson
@@ -51,6 +51,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Biermereng"
     ],
+    "name:ltz_x_variant":[
+        "Biermereng"
+    ],
     "name:msa_x_preferred":[
         "Burmerange"
     ],
@@ -76,6 +79,9 @@
         "Burmerange"
     ],
     "name:swe_x_preferred":[
+        "Burmerange"
+    ],
+    "name:tur_x_preferred":[
         "Burmerange"
     ],
     "name:ukr_x_preferred":[
@@ -110,11 +116,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1745980847,
         85633275,
-        1125883515
+        1125883515,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -147,7 +153,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733199,
+    "wof:lastmodified":1690938732,
     "wof:name":"Burmerange",
     "wof:parent_id":1125883515,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/690/7/1745986907.geojson
+++ b/data/174/598/690/7/1745986907.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Oberdonven"
     ],
+    "name:deu_x_preferred":[
+        "Oberdonven"
+    ],
     "name:eng_x_preferred":[
         "Oberdonven"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125284029,
         85633275,
-        101854571
+        101854571,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733200,
+    "wof:lastmodified":1690938731,
     "wof:name":"Oberdonven",
     "wof:parent_id":101854571,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/691/1/1745986911.geojson
+++ b/data/174/598/691/1/1745986911.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Niederdonven"
+    ],
     "name:cat_x_preferred":[
         "Niederdonven"
     ],
     "name:ceb_x_preferred":[
+        "Niederdonven"
+    ],
+    "name:deu_x_preferred":[
         "Niederdonven"
     ],
     "name:eng_x_preferred":[
@@ -71,11 +77,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125284029,
         85633275,
-        101854571
+        101854571,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733203,
+    "wof:lastmodified":1690938734,
     "wof:name":"Niederdonven",
     "wof:parent_id":101854571,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/691/3/1745986913.geojson
+++ b/data/174/598/691/3/1745986913.geojson
@@ -24,6 +24,9 @@
     "name:cat_x_preferred":[
         "Leithum"
     ],
+    "name:deu_x_preferred":[
+        "Leithum"
+    ],
     "name:eng_x_preferred":[
         "Leithum"
     ],
@@ -62,11 +65,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125352025,
         85633275,
-        1125800297
+        1125800297,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,7 +102,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733204,
+    "wof:lastmodified":1690938734,
     "wof:name":"Leithum",
     "wof:parent_id":1125800297,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/691/7/1745986917.geojson
+++ b/data/174/598/691/7/1745986917.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "M\u00fcllendorf"
     ],
+    "name:ces_x_preferred":[
+        "Mullendorf"
+    ],
     "name:eng_x_preferred":[
         "Mullendorf"
     ],
@@ -72,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125305385,
         85633275,
-        101753069
+        101753069,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733206,
+    "wof:lastmodified":1690938734,
     "wof:name":"M\u00fcllendorf",
     "wof:parent_id":101753069,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/692/1/1745986921.geojson
+++ b/data/174/598/692/1/1745986921.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Moutfort"
+    ],
     "name:cat_x_preferred":[
         "Moutfort"
     ],
@@ -48,6 +51,9 @@
     "name:swe_x_preferred":[
         "Moutfort"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0443\u0442\u0444\u043e\u0440\u0442"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -72,11 +78,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1745980849,
         85633275,
-        101812909
+        101812909,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733209,
+    "wof:lastmodified":1690938712,
     "wof:name":"Moutfort",
     "wof:parent_id":101812909,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/692/5/1745986925.geojson
+++ b/data/174/598/692/5/1745986925.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Schrassig"
+    ],
     "name:cat_x_preferred":[
         "Schrassig"
     ],
@@ -51,6 +54,9 @@
     "name:swe_x_variant":[
         "Moutfort"
     ],
+    "name:ukr_x_preferred":[
+        "\u0428\u0440\u0430\u0441\u0441\u0456\u0433"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -77,11 +83,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125375263,
         85633275,
-        101812899
+        101812899,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733210,
+    "wof:lastmodified":1690938713,
     "wof:name":"Schrassig",
     "wof:parent_id":101812899,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/692/7/1745986927.geojson
+++ b/data/174/598/692/7/1745986927.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Niederpallen"
+    ],
     "name:cat_x_preferred":[
         "Niederpallen"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125402395,
         85633275,
-        101845561
+        101845561,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733211,
+    "wof:lastmodified":1690938712,
     "wof:name":"Niederpallen",
     "wof:parent_id":101845561,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/692/9/1745986929.geojson
+++ b/data/174/598/692/9/1745986929.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Hoffelt"
+    ],
     "name:cat_x_preferred":[
         "Hoffelt"
     ],
@@ -35,6 +38,9 @@
     ],
     "name:fra_x_preferred":[
         "Hoffelt"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30db\u30c3\u30d5\u30a7\u30eb\u30c8"
     ],
     "name:ltz_x_preferred":[
         "Houfelt"
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1745980853,
         85633275,
-        101811727
+        101811727,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733212,
+    "wof:lastmodified":1690938712,
     "wof:name":"Hoffelt",
     "wof:parent_id":101811727,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/693/1/1745986931.geojson
+++ b/data/174/598/693/1/1745986931.geojson
@@ -27,8 +27,14 @@
     "name:ceb_x_preferred":[
         "Harlange"
     ],
+    "name:deu_x_preferred":[
+        "Harlingen"
+    ],
     "name:eng_x_preferred":[
         "Harlange"
+    ],
+    "name:fas_x_preferred":[
+        "\u0647\u0627\u0631\u0644\u0627\u0646\u062c"
     ],
     "name:fra_x_preferred":[
         "Harlange"
@@ -41,6 +47,9 @@
     ],
     "name:swe_x_preferred":[
         "Harlange"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u5c14\u6717\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -68,11 +77,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125283425,
         85633275,
-        1126028027
+        1126028027,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -105,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733213,
+    "wof:lastmodified":1690938711,
     "wof:name":"Harlange",
     "wof:parent_id":1126028027,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/693/3/1745986933.geojson
+++ b/data/174/598/693/3/1745986933.geojson
@@ -30,14 +30,23 @@
     "name:ceb_x_preferred":[
         "Ahn"
     ],
+    "name:deu_x_preferred":[
+        "Ahn"
+    ],
     "name:eng_x_preferred":[
         "Ahn"
     ],
     "name:fra_x_preferred":[
         "Ahn"
     ],
+    "name:lit_x_preferred":[
+        "Onas"
+    ],
     "name:ltz_x_preferred":[
         "On"
+    ],
+    "name:ltz_x_variant":[
+        "Ohn"
     ],
     "name:msa_x_preferred":[
         "Ahn"
@@ -76,12 +85,12 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85682491,
         102191581,
         1125311551,
         85633111,
         101813323,
-        102063545
+        102063545,
+        85682491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,7 +124,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733215,
+    "wof:lastmodified":1690938712,
     "wof:name":"Ahn",
     "wof:parent_id":101813323,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/694/3/1745986943.geojson
+++ b/data/174/598/694/3/1745986943.geojson
@@ -48,6 +48,9 @@
     "name:swe_x_preferred":[
         "Medingen"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0435\u0434\u0456\u043d\u0433\u0435\u043d"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1745980849,
         85633275,
-        101812909
+        101812909,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733219,
+    "wof:lastmodified":1690938710,
     "wof:name":"Medingen",
     "wof:parent_id":101812909,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/694/5/1745986945.geojson
+++ b/data/174/598/694/5/1745986945.geojson
@@ -33,6 +33,12 @@
     "name:fra_x_preferred":[
         "Hassel"
     ],
+    "name:ita_x_preferred":[
+        "Hassel"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30cf\u30c3\u30bb\u30eb"
+    ],
     "name:ltz_x_preferred":[
         "Haassel"
     ],
@@ -69,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125285789,
         85633275,
-        101845567
+        101845567,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733221,
+    "wof:lastmodified":1690938710,
     "wof:name":"Hassel",
     "wof:parent_id":101845567,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/694/7/1745986947.geojson
+++ b/data/174/598/694/7/1745986947.geojson
@@ -45,6 +45,9 @@
     "name:eng_x_preferred":[
         "Mecher"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u06cc\u0686\u0631"
+    ],
     "name:fra_x_preferred":[
         "Mecher"
     ],
@@ -113,11 +116,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125283425,
         85633275,
-        1126028027
+        1126028027,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -150,7 +153,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733222,
+    "wof:lastmodified":1690938710,
     "wof:name":"Mecher-sur-Clervaux",
     "wof:parent_id":1126028027,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/694/9/1745986949.geojson
+++ b/data/174/598/694/9/1745986949.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "\u00dcbersyren"
+    ],
     "name:cat_x_preferred":[
         "\u00dcbersyren"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:swe_x_preferred":[
         "Uebersyren"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0423\u0431\u0435\u0440\u0441\u0456\u0440\u0435\u043d"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -69,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125375263,
         85633275,
-        101812899
+        101812899,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733223,
+    "wof:lastmodified":1690938709,
     "wof:name":"Uebersyren",
     "wof:parent_id":101812899,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/695/1/1745986951.geojson
+++ b/data/174/598/695/1/1745986951.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Gosseldange"
+    ],
     "name:cat_x_preferred":[
         "Gosseldange"
     ],
@@ -72,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125288915,
         85633275,
-        101812885
+        101812885,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733224,
+    "wof:lastmodified":1690938713,
     "wof:name":"Gosseldange",
     "wof:parent_id":101812885,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/695/3/1745986953.geojson
+++ b/data/174/598/695/3/1745986953.geojson
@@ -24,6 +24,9 @@
     "name:cat_x_preferred":[
         "Grummelscheid"
     ],
+    "name:deu_x_preferred":[
+        "Gr\u00fcmelscheid"
+    ],
     "name:eng_x_preferred":[
         "Grummelscheid"
     ],
@@ -65,11 +68,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125284497,
         85633275,
-        1126025653
+        1126025653,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +105,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733225,
+    "wof:lastmodified":1690938714,
     "wof:name":"Gr\u00fcmmelscheid",
     "wof:parent_id":1126025653,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/695/5/1745986955.geojson
+++ b/data/174/598/695/5/1745986955.geojson
@@ -30,6 +30,9 @@
     "name:eng_x_preferred":[
         "Pintsch"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u06cc\u0646\u062a\u0686"
+    ],
     "name:fra_x_preferred":[
         "Pintsch"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125312135,
         85633275,
-        1745984181
+        1745984181,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733227,
+    "wof:lastmodified":1690938714,
     "wof:name":"Pintsch",
     "wof:parent_id":1745984181,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/695/7/1745986957.geojson
+++ b/data/174/598/695/7/1745986957.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Keispelt"
     ],
+    "name:deu_x_preferred":[
+        "Keispelt"
+    ],
     "name:eng_x_preferred":[
         "Keispelt"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125376161,
         85633275,
-        101812895
+        101812895,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733228,
+    "wof:lastmodified":1690938713,
     "wof:name":"Keispelt",
     "wof:parent_id":101812895,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/696/3/1745986963.geojson
+++ b/data/174/598/696/3/1745986963.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Derenbach"
     ],
+    "name:deu_x_preferred":[
+        "Derenbach"
+    ],
     "name:eng_x_preferred":[
         "Derenbach"
     ],
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1745980853,
         85633275,
-        101811727
+        101811727,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733230,
+    "wof:lastmodified":1690938733,
     "wof:name":"Derenbach",
     "wof:parent_id":101811727,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/696/5/1745986965.geojson
+++ b/data/174/598/696/5/1745986965.geojson
@@ -36,6 +36,9 @@
     "name:ltz_x_preferred":[
         "Bitscht"
     ],
+    "name:ltz_x_variant":[
+        "Bidscht"
+    ],
     "name:msa_x_preferred":[
         "Buderscheid"
     ],
@@ -72,11 +75,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125298213,
         85633275,
-        1125882147
+        1125882147,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733231,
+    "wof:lastmodified":1690938734,
     "wof:name":"Buderscheid",
     "wof:parent_id":1125882147,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/696/7/1745986967.geojson
+++ b/data/174/598/696/7/1745986967.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Bastendorf"
+    ],
     "name:cat_x_preferred":[
         "Bastendorf"
     ],
@@ -32,6 +35,9 @@
     ],
     "name:eng_x_preferred":[
         "Bastendorf"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0633\u062a\u0646\u062f\u0648\u0631\u0641"
     ],
     "name:fra_x_preferred":[
         "Bastendorf"
@@ -50,6 +56,9 @@
     ],
     "name:swe_x_preferred":[
         "Bastendorf"
+    ],
+    "name:zho_x_preferred":[
+        "\u5df4\u65af\u6ed5\u591a\u592b"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -77,11 +86,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977449,
         102191581,
         1745980851,
         85633275,
-        1125952365
+        1125952365,
+        1745977449
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,7 +123,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733232,
+    "wof:lastmodified":1690938733,
     "wof:name":"Bastendorf",
     "wof:parent_id":1125952365,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/696/9/1745986969.geojson
+++ b/data/174/598/696/9/1745986969.geojson
@@ -21,14 +21,26 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Canach"
+    ],
     "name:cat_x_preferred":[
         "Canach"
     ],
     "name:ceb_x_preferred":[
         "Canach"
     ],
+    "name:ces_x_preferred":[
+        "Kanech"
+    ],
+    "name:deu_x_preferred":[
+        "Kanech"
+    ],
     "name:eng_x_preferred":[
         "Canach"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0646\u0627\u0686"
     ],
     "name:fra_x_preferred":[
         "Canach"
@@ -44,6 +56,9 @@
     ],
     "name:pol_x_preferred":[
         "Canach"
+    ],
+    "name:slk_x_preferred":[
+        "Kanech"
     ],
     "name:swe_x_preferred":[
         "Canach"
@@ -74,11 +89,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1125325879,
         85633275,
-        101854573
+        101854573,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +126,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733234,
+    "wof:lastmodified":1690938733,
     "wof:name":"Canach",
     "wof:parent_id":101854573,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/697/1/1745986971.geojson
+++ b/data/174/598/697/1/1745986971.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Gonderange"
+    ],
     "name:cat_x_preferred":[
         "Gonderange"
     ],
@@ -79,11 +82,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125296455,
         85633275,
-        101812889
+        101812889,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,7 +119,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733235,
+    "wof:lastmodified":1690938732,
     "wof:name":"Gonderange",
     "wof:parent_id":101812889,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/697/3/1745986973.geojson
+++ b/data/174/598/697/3/1745986973.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Nagem"
     ],
+    "name:deu_x_preferred":[
+        "Nagem"
+    ],
     "name:eng_x_preferred":[
         "Nagem"
     ],
@@ -75,11 +78,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125402395,
         85633275,
-        101845561
+        101845561,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733236,
+    "wof:lastmodified":1690938732,
     "wof:name":"Nagem",
     "wof:parent_id":101845561,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/697/9/1745986979.geojson
+++ b/data/174/598/697/9/1745986979.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Everlange"
+    ],
     "name:cat_x_preferred":[
         "Everlange"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125366387,
         85633275,
-        101812881
+        101812881,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733238,
+    "wof:lastmodified":1690938732,
     "wof:name":"Everlange",
     "wof:parent_id":101812881,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/698/3/1745986983.geojson
+++ b/data/174/598/698/3/1745986983.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Senningen"
+    ],
     "name:cat_x_preferred":[
         "Senningen"
     ],
@@ -32,6 +35,9 @@
     ],
     "name:eng_x_preferred":[
         "Senningen"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646\u06cc\u0646\u06af\u0646"
     ],
     "name:fra_x_preferred":[
         "Senningen"
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Rheinland-Pfalz",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125410759,
         85633275,
-        101753075
+        101753075,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733241,
+    "wof:lastmodified":1690938734,
     "wof:name":"Steiningen",
     "wof:parent_id":101753075,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/698/5/1745986985.geojson
+++ b/data/174/598/698/5/1745986985.geojson
@@ -51,6 +51,9 @@
     "name:ita_x_preferred":[
         "Septfontaines"
     ],
+    "name:lim_x_preferred":[
+        "Septfontaines"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Simmer"
     ],
@@ -82,6 +85,9 @@
         "Septfontaines"
     ],
     "name:swe_x_preferred":[
+        "Septfontaines"
+    ],
+    "name:tur_x_preferred":[
         "Septfontaines"
     ],
     "name:ukr_x_preferred":[
@@ -118,11 +124,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125284213,
         85633275,
-        101845565
+        101845565,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -155,7 +161,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733242,
+    "wof:lastmodified":1690938735,
     "wof:name":"Septfontaines",
     "wof:parent_id":101845565,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/699/3/1745986993.geojson
+++ b/data/174/598/699/3/1745986993.geojson
@@ -45,6 +45,9 @@
     "name:swe_x_preferred":[
         "Bofferdange"
     ],
+    "name:zho_x_preferred":[
+        "\u6ce2\u5f17\u4e39\u683c"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -69,11 +72,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125366377,
         85633275,
-        1125990641
+        1125990641,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733247,
+    "wof:lastmodified":1690938731,
     "wof:name":"Bofferdange",
     "wof:parent_id":1125990641,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/699/7/1745986997.geojson
+++ b/data/174/598/699/7/1745986997.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Belvaux"
+    ],
     "name:cat_x_preferred":[
         "Belvaux"
     ],
@@ -36,6 +39,9 @@
     "name:fra_x_preferred":[
         "Belvaux"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d9\u30eb\u30f4\u30a9\u30fc"
+    ],
     "name:lav_x_preferred":[
         "Belvo"
     ],
@@ -46,6 +52,9 @@
         "Bieles"
     ],
     "name:nld_x_preferred":[
+        "Belvaux"
+    ],
+    "name:nob_x_preferred":[
         "Belvaux"
     ],
     "name:pol_x_preferred":[
@@ -83,11 +92,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125299915,
         85633275,
-        1126007057
+        1126007057,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,7 +129,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733248,
+    "wof:lastmodified":1690938731,
     "wof:name":"Belvaux",
     "wof:parent_id":1126007057,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/700/7/1745987007.geojson
+++ b/data/174/598/700/7/1745987007.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Altlinster"
     ],
+    "name:deu_x_preferred":[
+        "Altlinster"
+    ],
     "name:eng_x_preferred":[
         "Altlinster"
     ],
@@ -46,6 +49,9 @@
         "Altlinster"
     ],
     "name:swe_x_preferred":[
+        "Altlinster"
+    ],
+    "name:uzb_x_preferred":[
         "Altlinster"
     ],
     "qs_pg:aaroncc":"LU",
@@ -72,11 +78,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125296455,
         85633275,
-        101812889
+        101812889,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733254,
+    "wof:lastmodified":1690938702,
     "wof:name":"Altlinster",
     "wof:parent_id":101812889,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/701/5/1745987015.geojson
+++ b/data/174/598/701/5/1745987015.geojson
@@ -39,6 +39,9 @@
     "name:ltz_x_preferred":[
         "H\u00ebnchereng"
     ],
+    "name:ltz_x_variant":[
+        "Hunchereng"
+    ],
     "name:nld_x_preferred":[
         "Huncherange"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125357423,
         85633275,
-        101812917
+        101812917,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733257,
+    "wof:lastmodified":1690938697,
     "wof:name":"Huncherange",
     "wof:parent_id":101812917,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/702/5/1745987025.geojson
+++ b/data/174/598/702/5/1745987025.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Noertzange"
+    ],
     "name:cat_x_preferred":[
         "Noertzange"
     ],
@@ -79,11 +82,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125357423,
         85633275,
-        101812917
+        101812917,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,7 +119,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733263,
+    "wof:lastmodified":1690938721,
     "wof:name":"Noertzange",
     "wof:parent_id":101812917,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/702/9/1745987029.geojson
+++ b/data/174/598/702/9/1745987029.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Pratz"
     ],
+    "name:deu_x_preferred":[
+        "Pratz"
+    ],
     "name:eng_x_preferred":[
         "Pratz"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1745980841,
         85633275,
-        1745984183
+        1745984183,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733265,
+    "wof:lastmodified":1690938721,
     "wof:name":"Pratz",
     "wof:parent_id":1745984183,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/704/3/1745987043.geojson
+++ b/data/174/598/704/3/1745987043.geojson
@@ -30,6 +30,9 @@
     "name:eng_x_preferred":[
         "Kautenbach"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0648\u062a\u0646\u200c\u0628\u0627\u0686"
+    ],
     "name:fra_x_preferred":[
         "Kautenbach"
     ],
@@ -53,6 +56,9 @@
     ],
     "name:swe_x_preferred":[
         "Kautenbach"
+    ],
+    "name:zho_x_preferred":[
+        "\u8003\u6ed5\u5df4\u8d6b"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -82,11 +88,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125312135,
         85633275,
-        1745984181
+        1745984181,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -119,7 +125,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733272,
+    "wof:lastmodified":1690938724,
     "wof:name":"Kautenbach",
     "wof:parent_id":1745984181,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/704/5/1745987045.geojson
+++ b/data/174/598/704/5/1745987045.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Altwies"
+    ],
     "name:cat_x_preferred":[
         "Altwies"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1125366329,
         85633275,
-        101812921
+        101812921,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733273,
+    "wof:lastmodified":1690938725,
     "wof:name":"Altwies",
     "wof:parent_id":101812921,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/705/5/1745987055.geojson
+++ b/data/174/598/705/5/1745987055.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Blaschette"
+    ],
     "name:cat_x_preferred":[
         "Blaschette"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125366377,
         85633275,
-        1125990641
+        1125990641,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733278,
+    "wof:lastmodified":1690938721,
     "wof:name":"Blaschette",
     "wof:parent_id":1125990641,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/705/7/1745987057.geojson
+++ b/data/174/598/705/7/1745987057.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Imbringen"
     ],
+    "name:deu_x_preferred":[
+        "Imbringen"
+    ],
     "name:eng_x_preferred":[
         "Imbringen"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125296455,
         85633275,
-        101812889
+        101812889,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733279,
+    "wof:lastmodified":1690938720,
     "wof:name":"Imbringen",
     "wof:parent_id":101812889,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/705/9/1745987059.geojson
+++ b/data/174/598/705/9/1745987059.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Greisch"
     ],
+    "name:deu_x_preferred":[
+        "Greisch"
+    ],
     "name:eng_x_preferred":[
         "Greisch"
     ],
@@ -72,11 +75,11 @@
     "woe:name_adm1":"Lorraine",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125284213,
         85633275,
-        101845565
+        101845565,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733280,
+    "wof:lastmodified":1690938720,
     "wof:name":"Preisch",
     "wof:parent_id":101845565,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/706/3/1745987063.geojson
+++ b/data/174/598/706/3/1745987063.geojson
@@ -33,6 +33,9 @@
     "name:fra_x_preferred":[
         "Eppeldorf"
     ],
+    "name:ita_x_preferred":[
+        "Eppeldorf"
+    ],
     "name:ltz_x_preferred":[
         "Eppelduerf"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977441,
         102191581,
         1745980859,
         85633275,
-        1745984191
+        1745984191,
+        1745977441
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733283,
+    "wof:lastmodified":1690938697,
     "wof:name":"Eppeldorf",
     "wof:parent_id":1745984191,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/707/1/1745987071.geojson
+++ b/data/174/598/707/1/1745987071.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Huldange"
+    ],
     "name:cat_x_preferred":[
         "Huldange"
     ],
@@ -88,11 +91,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125352097,
         85633275,
-        1125811873
+        1125811873,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -125,7 +128,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733286,
+    "wof:lastmodified":1690938702,
     "wof:name":"Huldange",
     "wof:parent_id":1125811873,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/707/5/1745987075.geojson
+++ b/data/174/598/707/5/1745987075.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Schandel"
+    ],
     "name:cat_x_preferred":[
         "Schandel"
     ],
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125366387,
         85633275,
-        101812881
+        101812881,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733289,
+    "wof:lastmodified":1690938702,
     "wof:name":"Schandel",
     "wof:parent_id":101812881,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/708/1/1745987081.geojson
+++ b/data/174/598/708/1/1745987081.geojson
@@ -48,6 +48,9 @@
     "name:swe_x_preferred":[
         "Kleinbettingen"
     ],
+    "name:zho_x_preferred":[
+        "\u5c0f\u8d1d\u5ef7\u6839"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125346159,
         85633275,
-        1125777823
+        1125777823,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733292,
+    "wof:lastmodified":1690938698,
     "wof:name":"Kleinbettingen",
     "wof:parent_id":1125777823,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/709/1/1745987091.geojson
+++ b/data/174/598/709/1/1745987091.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Bettborn"
+    ],
     "name:cat_x_preferred":[
         "Bettborn"
     ],
@@ -38,6 +41,9 @@
     ],
     "name:ltz_x_preferred":[
         "Bieberech"
+    ],
+    "name:ltz_x_variant":[
+        "Biebereg"
     ],
     "name:msa_x_preferred":[
         "Bettborn"
@@ -88,11 +94,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1745980841,
         85633275,
-        1745984183
+        1745984183,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -125,7 +131,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733297,
+    "wof:lastmodified":1690938699,
     "wof:name":"Bettborn",
     "wof:parent_id":1745984183,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/709/5/1745987095.geojson
+++ b/data/174/598/709/5/1745987095.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Livange"
+    ],
     "name:cat_x_preferred":[
         "Livange"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125324091,
         85633275,
-        1125947927
+        1125947927,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733299,
+    "wof:lastmodified":1690938699,
     "wof:name":"Livange",
     "wof:parent_id":1125947927,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/709/9/1745987099.geojson
+++ b/data/174/598/709/9/1745987099.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Drinklange"
     ],
+    "name:deu_x_preferred":[
+        "Drinklingen"
+    ],
     "name:eng_x_preferred":[
         "Drinklange"
     ],
@@ -78,11 +81,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125352097,
         85633275,
-        1125811873
+        1125811873,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,7 +118,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733302,
+    "wof:lastmodified":1690938699,
     "wof:name":"Drinklange",
     "wof:parent_id":1125811873,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/710/1/1745987101.geojson
+++ b/data/174/598/710/1/1745987101.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Oberpallen"
+    ],
     "name:cat_x_preferred":[
         "Oberpallen"
     ],
@@ -32,6 +35,9 @@
     ],
     "name:eng_x_preferred":[
         "Oberpallen"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u0628\u0631\u067e\u0627\u0644\u0646"
     ],
     "name:fra_x_preferred":[
         "Oberpallen"
@@ -63,11 +69,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125325865,
         85633275,
-        101845563
+        101845563,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,7 +105,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733303,
+    "wof:lastmodified":1690938739,
     "wof:name":"Oberpallen",
     "wof:parent_id":101845563,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/710/9/1745987109.geojson
+++ b/data/174/598/710/9/1745987109.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Schouweiler"
+    ],
     "name:cat_x_preferred":[
         "Schouweiler"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125285649,
         85633275,
-        101812907
+        101812907,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733306,
+    "wof:lastmodified":1690938739,
     "wof:name":"Schouweiler",
     "wof:parent_id":101812907,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/711/1/1745987111.geojson
+++ b/data/174/598/711/1/1745987111.geojson
@@ -39,6 +39,9 @@
     "name:ltz_x_preferred":[
         "Merscheet"
     ],
+    "name:ltz_x_variant":[
+        "M\u00ebtscheed"
+    ],
     "name:msa_x_preferred":[
         "Merscheid"
     ],
@@ -46,6 +49,9 @@
         "Merscheid"
     ],
     "name:pol_x_preferred":[
+        "Merscheid"
+    ],
+    "name:por_x_preferred":[
         "Merscheid"
     ],
     "name:swe_x_preferred":[
@@ -75,11 +81,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125333105,
         85633275,
-        1125776761
+        1125776761,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,7 +118,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733308,
+    "wof:lastmodified":1690938740,
     "wof:name":"Merscheid-l\u00e8s-Heiderscheid",
     "wof:parent_id":1125776761,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/711/5/1745987115.geojson
+++ b/data/174/598/711/5/1745987115.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Oberanven"
+    ],
     "name:cat_x_preferred":[
         "Oberanven"
     ],
     "name:ceb_x_preferred":[
+        "Oberanven"
+    ],
+    "name:deu_x_preferred":[
         "Oberanven"
     ],
     "name:eng_x_preferred":[
@@ -47,6 +53,9 @@
     ],
     "name:swe_x_preferred":[
         "Oberanven"
+    ],
+    "name:zho_x_preferred":[
+        "\u4e0a\u5b89\u6587"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -74,11 +83,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125410759,
         85633275,
-        101753075
+        101753075,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733310,
+    "wof:lastmodified":1690938740,
     "wof:name":"Oberanven",
     "wof:parent_id":101753075,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/711/9/1745987119.geojson
+++ b/data/174/598/711/9/1745987119.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Gostingen"
+    ],
     "name:cat_x_preferred":[
         "Gostingen"
     ],
     "name:ceb_x_preferred":[
+        "Gostingen"
+    ],
+    "name:deu_x_preferred":[
         "Gostingen"
     ],
     "name:eng_x_preferred":[
@@ -71,11 +77,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125284029,
         85633275,
-        101854571
+        101854571,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733312,
+    "wof:lastmodified":1690938740,
     "wof:name":"Gostingen",
     "wof:parent_id":101854571,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/712/3/1745987123.geojson
+++ b/data/174/598/712/3/1745987123.geojson
@@ -33,11 +33,17 @@
     "name:eng_x_preferred":[
         "Folschette"
     ],
+    "name:fas_x_preferred":[
+        "\u0641\u0648\u0644\u0633\u0686\u062a"
+    ],
     "name:fra_x_preferred":[
         "Folschette"
     ],
     "name:ltz_x_preferred":[
         "Foulscht"
+    ],
+    "name:ltz_x_variant":[
+        "Folscht"
     ],
     "name:nld_x_preferred":[
         "Folschette"
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125410765,
         85633275,
-        101812867
+        101812867,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733313,
+    "wof:lastmodified":1690938718,
     "wof:name":"Folschette",
     "wof:parent_id":101812867,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/712/5/1745987125.geojson
+++ b/data/174/598/712/5/1745987125.geojson
@@ -48,8 +48,14 @@
     "name:pol_x_preferred":[
         "Nospelt"
     ],
+    "name:rus_x_preferred":[
+        "\u041d\u043e\u0441\u043f\u0435\u043b\u044c\u0442"
+    ],
     "name:swe_x_preferred":[
         "Nospelt"
+    ],
+    "name:zho_x_preferred":[
+        "\u8afe\u65af\u4f69\u723e\u7279"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -77,11 +83,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125376161,
         85633275,
-        101812895
+        101812895,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733314,
+    "wof:lastmodified":1690938718,
     "wof:name":"Nospelt",
     "wof:parent_id":101812895,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/712/9/1745987129.geojson
+++ b/data/174/598/712/9/1745987129.geojson
@@ -39,6 +39,9 @@
     "name:eng_x_preferred":[
         "Medernach"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u062f\u0631\u0646\u0627\u0686"
+    ],
     "name:fra_x_preferred":[
         "Medernach"
     ],
@@ -47,6 +50,12 @@
     ],
     "name:ita_x_preferred":[
         "Medernach"
+    ],
+    "name:lim_x_preferred":[
+        "Medernach"
+    ],
+    "name:lit_x_preferred":[
+        "Medernachas"
     ],
     "name:ltz_x_preferred":[
         "Miedernach"
@@ -73,6 +82,9 @@
         "Medernach"
     ],
     "name:swe_x_preferred":[
+        "Medernach"
+    ],
+    "name:tur_x_preferred":[
         "Medernach"
     ],
     "name:ukr_x_preferred":[
@@ -104,11 +116,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977441,
         102191581,
         1745980859,
         85633275,
-        1745984191
+        1745984191,
+        1745977441
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -141,7 +153,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733317,
+    "wof:lastmodified":1690938718,
     "wof:name":"Medernach",
     "wof:parent_id":1745984191,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/713/1/1745987131.geojson
+++ b/data/174/598/713/1/1745987131.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Helmdange"
+    ],
     "name:cat_x_preferred":[
         "Helmdange"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125366377,
         85633275,
-        1125990641
+        1125990641,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733318,
+    "wof:lastmodified":1690938716,
     "wof:name":"Helmdange",
     "wof:parent_id":1125990641,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/713/5/1745987135.geojson
+++ b/data/174/598/713/5/1745987135.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Hautbellain"
     ],
+    "name:deu_x_preferred":[
+        "Oberbesslingen"
+    ],
     "name:eng_x_preferred":[
         "Hautbellain"
     ],
@@ -83,11 +86,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125352097,
         85633275,
-        1125811873
+        1125811873,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,7 +123,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733320,
+    "wof:lastmodified":1690938716,
     "wof:name":"Hautbellain",
     "wof:parent_id":1125811873,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/713/7/1745987137.geojson
+++ b/data/174/598/713/7/1745987137.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Ehlange-sur-Mess"
+    ],
     "name:cat_x_preferred":[
         "Ehlange-sur-Mess"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1745980833,
         85633275,
-        1125880997
+        1125880997,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733321,
+    "wof:lastmodified":1690938715,
     "wof:name":"Ehlange",
     "wof:parent_id":1125880997,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/714/1/1745987141.geojson
+++ b/data/174/598/714/1/1745987141.geojson
@@ -54,6 +54,9 @@
     "name:swe_x_preferred":[
         "Findel"
     ],
+    "name:zho_x_preferred":[
+        "\u82ac\u5fb7\u5c14"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -80,11 +83,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125366287,
         85633275,
-        1126007063
+        1126007063,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733323,
+    "wof:lastmodified":1690938716,
     "wof:name":"Findel",
     "wof:parent_id":1126007063,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/714/7/1745987147.geojson
+++ b/data/174/598/714/7/1745987147.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Christnach"
+    ],
     "name:cat_x_preferred":[
         "Christnach"
     ],
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977445,
         102191581,
         1125305359,
         85633275,
-        1125809215
+        1125809215,
+        1745977445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733326,
+    "wof:lastmodified":1690938716,
     "wof:name":"Christnach",
     "wof:parent_id":1125809215,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/714/9/1745987149.geojson
+++ b/data/174/598/714/9/1745987149.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Olm"
     ],
+    "name:deu_x_preferred":[
+        "Olm"
+    ],
     "name:eng_x_preferred":[
         "Olm"
     ],
@@ -73,11 +76,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125376161,
         85633275,
-        101812895
+        101812895,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,7 +113,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733327,
+    "wof:lastmodified":1690938716,
     "wof:name":"Olm",
     "wof:parent_id":101812895,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/715/3/1745987153.geojson
+++ b/data/174/598/715/3/1745987153.geojson
@@ -27,6 +27,9 @@
     "name:cat_x_preferred":[
         "Rodange"
     ],
+    "name:dan_x_preferred":[
+        "Rodange"
+    ],
     "name:deu_x_preferred":[
         "Rodingen"
     ],
@@ -51,8 +54,17 @@
     "name:pol_x_preferred":[
         "Rodange"
     ],
+    "name:spa_x_preferred":[
+        "Rodange"
+    ],
     "name:swe_x_preferred":[
         "Rodange"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0420\u043e\u0434\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u7f57\u5f53\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -82,11 +94,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125283405,
         85633275,
-        101839813
+        101839813,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -119,7 +131,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733330,
+    "wof:lastmodified":1690938718,
     "wof:name":"Rodange",
     "wof:parent_id":101839813,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/715/9/1745987159.geojson
+++ b/data/174/598/715/9/1745987159.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Marnach"
+    ],
     "name:cat_x_preferred":[
         "Marnach"
     ],
@@ -35,6 +38,9 @@
     ],
     "name:fra_x_preferred":[
         "Marnach"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30eb\u30ca\u30c3\u30cf"
     ],
     "name:ltz_x_preferred":[
         "Maarnech"
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125411213,
         85633275,
-        101811723
+        101811723,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733332,
+    "wof:lastmodified":1690938717,
     "wof:name":"Marnach",
     "wof:parent_id":101811723,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/717/7/1745987177.geojson
+++ b/data/174/598/717/7/1745987177.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Hunsdorf"
+    ],
     "name:cat_x_preferred":[
         "Hunsdorf"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125366377,
         85633275,
-        1125990641
+        1125990641,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733341,
+    "wof:lastmodified":1690938738,
     "wof:name":"Hunsdorf",
     "wof:parent_id":1125990641,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/718/1/1745987181.geojson
+++ b/data/174/598/718/1/1745987181.geojson
@@ -48,6 +48,9 @@
     "name:nld_x_preferred":[
         "Ansembourg"
     ],
+    "name:uzb_x_preferred":[
+        "Ansembourg"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1745980845,
         85633275,
-        1745984177
+        1745984177,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733344,
+    "wof:lastmodified":1690938744,
     "wof:name":"Ansembourg",
     "wof:parent_id":1745984177,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/718/5/1745987185.geojson
+++ b/data/174/598/718/5/1745987185.geojson
@@ -27,14 +27,23 @@
     "name:ceb_x_preferred":[
         "Angelsberg"
     ],
+    "name:deu_x_preferred":[
+        "Angelsberg"
+    ],
     "name:eng_x_preferred":[
         "Angelsberg"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0646\u06af\u0644\u0633\u0628\u0631\u06af"
     ],
     "name:fra_x_preferred":[
         "Angelsberg"
     ],
     "name:ltz_x_preferred":[
         "Aangelsbierg"
+    ],
+    "name:ltz_x_variant":[
+        "Angelsbierg"
     ],
     "name:nld_x_preferred":[
         "Angelsberg"
@@ -71,11 +80,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125305509,
         85633275,
-        1126048921
+        1126048921,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733346,
+    "wof:lastmodified":1690938744,
     "wof:name":"Angelsberg",
     "wof:parent_id":1126048921,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/719/5/1745987195.geojson
+++ b/data/174/598/719/5/1745987195.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Rollingen"
+    ],
     "name:cat_x_preferred":[
         "Rollingen"
     ],
@@ -32,6 +35,9 @@
     ],
     "name:fra_x_preferred":[
         "Rollingen"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ed\u30fc\u30ea\u30f3\u30b2\u30f3"
     ],
     "name:ltz_x_preferred":[
         "Rolleng"
@@ -69,11 +75,11 @@
     "woe:name_adm1":"Rheinland-Pfalz",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1125286143,
         85633275,
-        101812883
+        101812883,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733351,
+    "wof:lastmodified":1690938737,
     "wof:name":"Rohlingen",
     "wof:parent_id":101812883,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/719/7/1745987197.geojson
+++ b/data/174/598/719/7/1745987197.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Moersdorf"
+    ],
     "name:cat_x_preferred":[
         "Moersdorf"
     ],
@@ -80,11 +83,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977445,
         102191581,
         1745980855,
         85633275,
-        1745984189
+        1745984189,
+        1745977445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733352,
+    "wof:lastmodified":1690938737,
     "wof:name":"Moersdorf",
     "wof:parent_id":1745984189,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/719/9/1745987199.geojson
+++ b/data/174/598/719/9/1745987199.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Born"
+    ],
     "name:cat_x_preferred":[
         "Born"
     ],
@@ -74,12 +77,12 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85682491,
         102191581,
         1377686073,
         85633111,
         101855621,
-        102063545
+        102063545,
+        85682491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733353,
+    "wof:lastmodified":1690938737,
     "wof:name":"Moulin de Born",
     "wof:parent_id":101855621,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/720/5/1745987205.geojson
+++ b/data/174/598/720/5/1745987205.geojson
@@ -24,6 +24,9 @@
     "name:cat_x_preferred":[
         "Bereldange"
     ],
+    "name:ces_x_preferred":[
+        "Bereldange"
+    ],
     "name:deu_x_preferred":[
         "Bereldingen"
     ],
@@ -40,6 +43,9 @@
         "Bereldange"
     ],
     "name:pol_x_preferred":[
+        "Bereldange"
+    ],
+    "name:swe_x_preferred":[
         "Bereldange"
     ],
     "name:und_x_variant":[
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125355305,
         85633275,
-        101753071
+        101753071,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733357,
+    "wof:lastmodified":1690938743,
     "wof:name":"Bereldange",
     "wof:parent_id":101753071,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/720/7/1745987207.geojson
+++ b/data/174/598/720/7/1745987207.geojson
@@ -78,6 +78,9 @@
     "name:por_x_preferred":[
         "Tuntange"
     ],
+    "name:pus_x_preferred":[
+        "\u067c\u0648\u0646\u067c\u0627\u0646\u06ab"
+    ],
     "name:rus_x_preferred":[
         "\u0422\u0443\u043d\u0442\u0430\u043d\u0436"
     ],
@@ -87,11 +90,17 @@
     "name:swe_x_preferred":[
         "Tuntange"
     ],
+    "name:tur_x_preferred":[
+        "Tuntange"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0443\u043d\u0442\u0430\u043d\u0436"
     ],
     "name:und_x_variant":[
         "Tuntingen"
+    ],
+    "name:zho_x_preferred":[
+        "\u5766\u5510\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -119,11 +128,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1745980845,
         85633275,
-        1745984177
+        1745984177,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -156,7 +165,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733358,
+    "wof:lastmodified":1690938742,
     "wof:name":"Tuntange",
     "wof:parent_id":1745984177,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/720/9/1745987209.geojson
+++ b/data/174/598/720/9/1745987209.geojson
@@ -33,11 +33,17 @@
     "name:fra_x_preferred":[
         "Noertrange"
     ],
+    "name:hun_x_preferred":[
+        "Noertrange"
+    ],
     "name:jpn_x_preferred":[
         "\u30ce\u30a2\u30fc\u30c8\u30e9\u30f3\u30b2"
     ],
     "name:ltz_x_preferred":[
         "N\u00e4ertreg"
+    ],
+    "name:ltz_x_variant":[
+        "N\u00e4ertrech"
     ],
     "name:nld_x_preferred":[
         "Noertrange"
@@ -74,11 +80,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125284497,
         85633275,
-        1126025653
+        1126025653,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733359,
+    "wof:lastmodified":1690938742,
     "wof:name":"Noertrange",
     "wof:parent_id":1126025653,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/721/7/1745987217.geojson
+++ b/data/174/598/721/7/1745987217.geojson
@@ -21,10 +21,28 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Oetrange"
+    ],
+    "name:bre_x_preferred":[
+        "Oetrange"
+    ],
     "name:cat_x_preferred":[
         "Oetrange"
     ],
     "name:ceb_x_preferred":[
+        "Oetrange"
+    ],
+    "name:ces_x_preferred":[
+        "Oetrange"
+    ],
+    "name:cos_x_preferred":[
+        "Oetrange"
+    ],
+    "name:cym_x_preferred":[
+        "Oetrange"
+    ],
+    "name:dan_x_preferred":[
         "Oetrange"
     ],
     "name:deu_x_preferred":[
@@ -36,10 +54,37 @@
     "name:epo_x_preferred":[
         "Oetrange"
     ],
+    "name:est_x_preferred":[
+        "Oetrange"
+    ],
+    "name:fin_x_preferred":[
+        "Oetrange"
+    ],
     "name:fra_x_preferred":[
         "Oetrange"
     ],
+    "name:gle_x_preferred":[
+        "Oetrange"
+    ],
+    "name:glg_x_preferred":[
+        "Oetrange"
+    ],
+    "name:hrv_x_preferred":[
+        "Oetrange"
+    ],
     "name:hun_x_preferred":[
+        "Oetrange"
+    ],
+    "name:ind_x_preferred":[
+        "Oetrange"
+    ],
+    "name:ita_x_preferred":[
+        "Oetrange"
+    ],
+    "name:lav_x_preferred":[
+        "Oetrange"
+    ],
+    "name:lit_x_preferred":[
         "Oetrange"
     ],
     "name:ltz_x_preferred":[
@@ -51,11 +96,47 @@
     "name:nob_x_preferred":[
         "Oetrange"
     ],
+    "name:nrm_x_preferred":[
+        "Oetrange"
+    ],
+    "name:oci_x_preferred":[
+        "Oetrange"
+    ],
     "name:pol_x_preferred":[
+        "Oetrange"
+    ],
+    "name:por_x_preferred":[
+        "Oetrange"
+    ],
+    "name:ron_x_preferred":[
+        "Oetrange"
+    ],
+    "name:rus_x_preferred":[
+        "\u042d\u0442\u0440\u0438\u043d\u0433\u0435\u043d"
+    ],
+    "name:slk_x_preferred":[
+        "Oetrange"
+    ],
+    "name:slv_x_preferred":[
+        "Oetrange"
+    ],
+    "name:spa_x_preferred":[
         "Oetrange"
     ],
     "name:swe_x_preferred":[
         "Oetrange"
+    ],
+    "name:tah_x_preferred":[
+        "Oetrange"
+    ],
+    "name:tur_x_preferred":[
+        "Oetrange"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0415\u0442\u0440\u0430\u043d\u0436"
+    ],
+    "name:zho_x_preferred":[
+        "\u6b50\u723e\u4e39\u5947"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -85,11 +166,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1745980849,
         85633275,
-        101812909
+        101812909,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -122,7 +203,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733363,
+    "wof:lastmodified":1690938737,
     "wof:name":"Oetrange",
     "wof:parent_id":101812909,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/721/9/1745987219.geojson
+++ b/data/174/598/721/9/1745987219.geojson
@@ -33,6 +33,9 @@
     "name:eng_x_preferred":[
         "Doennange"
     ],
+    "name:fas_x_preferred":[
+        "\u062f\u0648\u0626\u06cc\u200c\u0646\u0627\u0631\u062c"
+    ],
     "name:fra_x_preferred":[
         "Doennange"
     ],
@@ -80,11 +83,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1745980853,
         85633275,
-        101811727
+        101811727,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733364,
+    "wof:lastmodified":1690938737,
     "wof:name":"Doennange",
     "wof:parent_id":101811727,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/722/5/1745987225.geojson
+++ b/data/174/598/722/5/1745987225.geojson
@@ -36,6 +36,9 @@
     "name:ltz_x_preferred":[
         "Beyeren"
     ],
+    "name:ltz_x_variant":[
+        "Beyren"
+    ],
     "name:nld_x_preferred":[
         "Beyren"
     ],
@@ -71,11 +74,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125284029,
         85633275,
-        101854571
+        101854571,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +111,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733367,
+    "wof:lastmodified":1690938714,
     "wof:name":"Beyren",
     "wof:parent_id":101854571,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/723/5/1745987235.geojson
+++ b/data/174/598/723/5/1745987235.geojson
@@ -21,11 +21,17 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Peppange"
+    ],
     "name:cat_x_preferred":[
         "Peppange"
     ],
     "name:ceb_x_preferred":[
         "Peppange"
+    ],
+    "name:deu_x_preferred":[
+        "Peppingen"
     ],
     "name:eng_x_preferred":[
         "Peppange"
@@ -71,11 +77,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125324091,
         85633275,
-        1125947927
+        1125947927,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733372,
+    "wof:lastmodified":1690938719,
     "wof:name":"Peppange",
     "wof:parent_id":1125947927,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/724/1/1745987241.geojson
+++ b/data/174/598/724/1/1745987241.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Bech-Kleinmacher"
+    ],
     "name:cat_x_preferred":[
         "Bech-Kleinmacher"
     ],
     "name:ceb_x_preferred":[
+        "Bech-Kleinmacher"
+    ],
+    "name:deu_x_preferred":[
         "Bech-Kleinmacher"
     ],
     "name:eng_x_preferred":[
@@ -69,11 +75,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1745980847,
         85633275,
-        1125883515
+        1125883515,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733375,
+    "wof:lastmodified":1690938719,
     "wof:name":"Kleinmacher",
     "wof:parent_id":1125883515,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/725/3/1745987253.geojson
+++ b/data/174/598/725/3/1745987253.geojson
@@ -45,6 +45,9 @@
     "name:pol_x_preferred":[
         "Tetange"
     ],
+    "name:pol_x_variant":[
+        "T\u00e9tange"
+    ],
     "name:por_x_preferred":[
         "T\u00e9tange"
     ],
@@ -77,11 +80,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125407267,
         85633275,
-        101839805
+        101839805,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733381,
+    "wof:lastmodified":1690938715,
     "wof:name":"T\u00e9tange",
     "wof:parent_id":101839805,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/725/7/1745987257.geojson
+++ b/data/174/598/725/7/1745987257.geojson
@@ -54,6 +54,9 @@
     "name:ita_x_preferred":[
         "Mompach"
     ],
+    "name:lim_x_preferred":[
+        "Mompach"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Mompech"
     ],
@@ -75,6 +78,9 @@
     "name:por_x_preferred":[
         "Mompach"
     ],
+    "name:pus_x_preferred":[
+        "\u0645\u0648\u0645\u067e\u06d0\u06a9"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u043e\u043c\u043f\u0430\u0445"
     ],
@@ -84,11 +90,17 @@
     "name:swe_x_preferred":[
         "Mompach"
     ],
+    "name:tur_x_preferred":[
+        "Mompach"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u043e\u043c\u043f\u0430\u0445"
     ],
     "name:urd_x_preferred":[
         "\u0645\u0645\u067e\u0627\u062e"
+    ],
+    "name:zho_x_preferred":[
+        "\u8499\u4f69\u723e\u67ef"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -114,11 +126,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977445,
         102191581,
         1745980855,
         85633275,
-        1745984189
+        1745984189,
+        1745977445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -151,7 +163,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733384,
+    "wof:lastmodified":1690938715,
     "wof:name":"Mompach",
     "wof:parent_id":1745984189,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/726/1/1745987261.geojson
+++ b/data/174/598/726/1/1745987261.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Filsdorf"
+    ],
     "name:cat_x_preferred":[
         "Filsdorf"
     ],
@@ -29,6 +32,9 @@
     ],
     "name:eng_x_preferred":[
         "Filsdorf"
+    ],
+    "name:fas_x_preferred":[
+        "\u0641\u06cc\u0644\u0633\u062f\u0648\u0631\u0641"
     ],
     "name:fra_x_preferred":[
         "Filsdorf"
@@ -71,11 +77,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977443,
         102191581,
         1125283997,
         85633275,
-        101812913
+        101812913,
+        1745977443
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733386,
+    "wof:lastmodified":1690938736,
     "wof:name":"Filsdorf",
     "wof:parent_id":101812913,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/726/3/1745987263.geojson
+++ b/data/174/598/726/3/1745987263.geojson
@@ -51,6 +51,9 @@
     "name:ltz_x_preferred":[
         "Gemeng N\u00e9ngsen"
     ],
+    "name:ltz_x_variant":[
+        "N\u00e9ngsen"
+    ],
     "name:msa_x_preferred":[
         "Neunhausen"
     ],
@@ -81,8 +84,14 @@
     "name:swe_x_preferred":[
         "Neunhausen"
     ],
+    "name:tur_x_preferred":[
+        "Neunhausen"
+    ],
     "name:ukr_x_preferred":[
         "\u041d\u043e\u0439\u043d\u0433\u0430\u0443\u0437\u0435\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u8bfa\u56e0\u8c6a\u68ee"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -112,11 +121,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125333105,
         85633275,
-        1125776761
+        1125776761,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -149,7 +158,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733387,
+    "wof:lastmodified":1690938736,
     "wof:name":"Neunhausen",
     "wof:parent_id":1125776761,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/727/1/1745987271.geojson
+++ b/data/174/598/727/1/1745987271.geojson
@@ -33,6 +33,9 @@
     "name:eng_x_preferred":[
         "Wilwerwiltz"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u06cc\u0644\u200c\u0648\u0631\u0648\u06cc\u0644\u062a\u0632"
+    ],
     "name:fra_x_preferred":[
         "Wilwerwiltz"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:und_x_variant":[
         "Wilwerwilz"
+    ],
+    "name:zho_x_preferred":[
+        "\u7ef4\u5c14\u6c83\u7ef4\u5c14\u8328"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -88,11 +94,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125312135,
         85633275,
-        1745984181
+        1745984181,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -125,7 +131,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733391,
+    "wof:lastmodified":1690938743,
     "wof:name":"Wilwerwiltz",
     "wof:parent_id":1745984181,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/728/1/1745987281.geojson
+++ b/data/174/598/728/1/1745987281.geojson
@@ -33,11 +33,20 @@
     "name:eng_x_preferred":[
         "Rombach"
     ],
+    "name:eng_x_variant":[
+        "Rombach-Martelange"
+    ],
     "name:fra_x_preferred":[
         "Rombach"
     ],
+    "name:fra_x_variant":[
+        "Rombach-Martelange"
+    ],
     "name:ltz_x_preferred":[
         "Rombech"
+    ],
+    "name:ltz_x_variant":[
+        "Roumecht"
     ],
     "name:nld_x_preferred":[
         "Rombach"
@@ -76,11 +85,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125410765,
         85633275,
-        101812867
+        101812867,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +122,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733397,
+    "wof:lastmodified":1690938739,
     "wof:name":"Rombach",
     "wof:parent_id":101812867,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/728/5/1745987285.geojson
+++ b/data/174/598/728/5/1745987285.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Colpach-Haut"
     ],
+    "name:deu_x_preferred":[
+        "Oberkolpach"
+    ],
     "name:eng_x_preferred":[
         "Colpach-Haut"
     ],
@@ -66,11 +69,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125306051,
         85633275,
-        1745984173
+        1745984173,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +105,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733398,
+    "wof:lastmodified":1690938739,
     "wof:name":"Colpach-Haut",
     "wof:parent_id":1745984173,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/728/7/1745987287.geojson
+++ b/data/174/598/728/7/1745987287.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Hellange"
+    ],
     "name:cat_x_preferred":[
         "Hellange"
     ],
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977435,
         102191581,
         1125410585,
         85633275,
-        101812919
+        101812919,
+        1745977435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733399,
+    "wof:lastmodified":1690938738,
     "wof:name":"Hellange",
     "wof:parent_id":101812919,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/728/9/1745987289.geojson
+++ b/data/174/598/728/9/1745987289.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Hoscheid"
+    ],
     "name:bar_x_preferred":[
         "Hoscheid"
     ],
@@ -41,6 +44,9 @@
     ],
     "name:eng_x_preferred":[
         "Hoscheid"
+    ],
+    "name:fas_x_preferred":[
+        "\u0647\u0648\u0633\u0686\u06cc\u062f"
     ],
     "name:fra_x_preferred":[
         "Hoscheid"
@@ -81,6 +87,9 @@
     "name:swe_x_preferred":[
         "Hoscheid"
     ],
+    "name:tur_x_preferred":[
+        "Hoscheid"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u043e\u0448\u0430\u0439\u0434"
     ],
@@ -115,11 +124,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125324097,
         85633275,
-        101845555
+        101845555,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -152,7 +161,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733400,
+    "wof:lastmodified":1690938738,
     "wof:name":"Hoscheid",
     "wof:parent_id":101845555,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/729/1/1745987291.geojson
+++ b/data/174/598/729/1/1745987291.geojson
@@ -54,6 +54,9 @@
     "name:ltz_x_preferred":[
         "Gemeng Munzen"
     ],
+    "name:ltz_x_variant":[
+        "Munzen"
+    ],
     "name:msa_x_preferred":[
         "Munshausen"
     ],
@@ -79,6 +82,9 @@
         "Munshausen"
     ],
     "name:swe_x_preferred":[
+        "Munshausen"
+    ],
+    "name:tur_x_preferred":[
         "Munshausen"
     ],
     "name:ukr_x_preferred":[
@@ -112,11 +118,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125411213,
         85633275,
-        101811723
+        101811723,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -149,7 +155,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733402,
+    "wof:lastmodified":1690938742,
     "wof:name":"Munshausen",
     "wof:parent_id":101811723,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/729/7/1745987297.geojson
+++ b/data/174/598/729/7/1745987297.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Colpach-Bas"
     ],
+    "name:deu_x_preferred":[
+        "Niederkolpach"
+    ],
     "name:eng_x_preferred":[
         "Colpach-Bas"
     ],
@@ -77,11 +80,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125306051,
         85633275,
-        1745984173
+        1745984173,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,7 +117,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733405,
+    "wof:lastmodified":1690938741,
     "wof:name":"Colpach-Bas",
     "wof:parent_id":1745984173,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/729/9/1745987299.geojson
+++ b/data/174/598/729/9/1745987299.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Basbellain"
     ],
+    "name:deu_x_preferred":[
+        "Niederbesslingen"
+    ],
     "name:eng_x_preferred":[
         "Basbellain"
     ],
@@ -80,11 +83,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125352097,
         85633275,
-        1125811873
+        1125811873,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733406,
+    "wof:lastmodified":1690938741,
     "wof:name":"Basbellain",
     "wof:parent_id":1125811873,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/731/1/1745987311.geojson
+++ b/data/174/598/731/1/1745987311.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Berbourg"
+    ],
     "name:cat_x_preferred":[
         "Berbourg"
     ],
@@ -36,8 +39,14 @@
     "name:fra_x_preferred":[
         "Berbourg"
     ],
+    "name:lit_x_preferred":[
+        "Berburgas"
+    ],
     "name:ltz_x_preferred":[
         "B\u00e4erbuerg"
+    ],
+    "name:ltz_x_variant":[
+        "Berbuerg"
     ],
     "name:nld_x_preferred":[
         "Berbourg"
@@ -74,11 +83,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125305331,
         85633275,
-        101812891
+        101812891,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +120,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733412,
+    "wof:lastmodified":1690938700,
     "wof:name":"Berbourg",
     "wof:parent_id":101812891,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/731/5/1745987315.geojson
+++ b/data/174/598/731/5/1745987315.geojson
@@ -51,6 +51,9 @@
     "name:swe_x_preferred":[
         "Hautcharage"
     ],
+    "name:zho_x_preferred":[
+        "\u6b27\u6c99\u62c9\u65e5"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -75,11 +78,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1745980843,
         85633275,
-        1745984179
+        1745984179,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,7 +115,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733415,
+    "wof:lastmodified":1690938700,
     "wof:name":"Hautcharage",
     "wof:parent_id":1745984179,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/732/3/1745987323.geojson
+++ b/data/174/598/732/3/1745987323.geojson
@@ -39,6 +39,9 @@
     "name:hun_x_preferred":[
         "Munsbach"
     ],
+    "name:lit_x_preferred":[
+        "Minsbechas"
+    ],
     "name:ltz_x_preferred":[
         "M\u00ebnsbech"
     ],
@@ -50,6 +53,9 @@
     ],
     "name:swe_x_preferred":[
         "M\u00fcnsbach"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u044e\u043d\u0441\u0431\u0430\u0445"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -75,11 +81,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125375263,
         85633275,
-        101812899
+        101812899,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,7 +118,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733418,
+    "wof:lastmodified":1690938723,
     "wof:name":"M\u00fcsbach",
     "wof:parent_id":101812899,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/732/7/1745987327.geojson
+++ b/data/174/598/732/7/1745987327.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Eselborn"
+    ],
     "name:cat_x_preferred":[
         "Eselborn"
     ],
@@ -38,6 +41,9 @@
     ],
     "name:ltz_x_preferred":[
         "Eeselbur"
+    ],
+    "name:ltz_x_variant":[
+        "Eeselbuer"
     ],
     "name:nld_x_preferred":[
         "Eselborn"
@@ -76,11 +82,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125411213,
         85633275,
-        101811723
+        101811723,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +119,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733420,
+    "wof:lastmodified":1690938723,
     "wof:name":"Eselborn",
     "wof:parent_id":101811723,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/733/3/1745987333.geojson
+++ b/data/174/598/733/3/1745987333.geojson
@@ -27,11 +27,17 @@
     "name:ceb_x_preferred":[
         "Helmsange"
     ],
+    "name:ces_x_preferred":[
+        "Helmsange"
+    ],
     "name:eng_x_preferred":[
         "Helmsange"
     ],
     "name:fra_x_preferred":[
         "Helmsange"
+    ],
+    "name:lit_x_preferred":[
+        "Helmsand\u017eas"
     ],
     "name:ltz_x_preferred":[
         "Helsem"
@@ -69,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125355305,
         85633275,
-        101753071
+        101753071,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733424,
+    "wof:lastmodified":1690938723,
     "wof:name":"Helmsange",
     "wof:parent_id":101753071,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/733/9/1745987339.geojson
+++ b/data/174/598/733/9/1745987339.geojson
@@ -30,6 +30,9 @@
     "name:ceb_x_preferred":[
         "Meispelt"
     ],
+    "name:deu_x_preferred":[
+        "Meispelt"
+    ],
     "name:eng_x_preferred":[
         "Meispelt"
     ],
@@ -72,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125376161,
         85633275,
-        101812895
+        101812895,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733426,
+    "wof:lastmodified":1690938722,
     "wof:name":"Meispelt",
     "wof:parent_id":101812895,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/734/1/1745987341.geojson
+++ b/data/174/598/734/1/1745987341.geojson
@@ -60,6 +60,9 @@
     "name:ltz_x_preferred":[
         "Gemeng B\u00e9iwen-Atert"
     ],
+    "name:ltz_x_variant":[
+        "B\u00e9iwen-Atert"
+    ],
     "name:msa_x_preferred":[
         "Boevange-sur-Attert"
     ],
@@ -87,11 +90,17 @@
     "name:swe_x_preferred":[
         "Boevange-sur-Attert"
     ],
+    "name:tur_x_preferred":[
+        "Boevange-sur-Attert"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0432\u0430\u043d\u0436-\u0441\u044e\u0440-\u0410\u0442\u0442\u0435\u0440\u0442"
     ],
     "name:und_x_variant":[
         "Bowen an der Attert"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u6cf0\u5c14\u7279\u6cb3\u7554\u4f2f\u65fa\u65e5"
     ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
@@ -119,11 +128,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1745980845,
         85633275,
-        1745984177
+        1745984177,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -156,7 +165,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733427,
+    "wof:lastmodified":1690938722,
     "wof:name":"Boevange-sur-Attert",
     "wof:parent_id":1745984177,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/734/5/1745987345.geojson
+++ b/data/174/598/734/5/1745987345.geojson
@@ -33,6 +33,9 @@
     "name:eng_x_preferred":[
         "Bigonville"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u06cc\u06af\u0648\u0646 \u0648\u06cc\u0644"
+    ],
     "name:fra_x_preferred":[
         "Bigonville"
     ],
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125410765,
         85633275,
-        101812867
+        101812867,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733430,
+    "wof:lastmodified":1690938722,
     "wof:name":"Bigonville",
     "wof:parent_id":101812867,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/734/7/1745987347.geojson
+++ b/data/174/598/734/7/1745987347.geojson
@@ -48,6 +48,9 @@
     "name:pol_x_preferred":[
         "Bourglinster"
     ],
+    "name:spa_x_preferred":[
+        "Bourglinster"
+    ],
     "name:swe_x_preferred":[
         "Bourglinster"
     ],
@@ -79,11 +82,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125296455,
         85633275,
-        101812889
+        101812889,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,7 +119,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733431,
+    "wof:lastmodified":1690938722,
     "wof:name":"Bourglinster",
     "wof:parent_id":101812889,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/734/9/1745987349.geojson
+++ b/data/174/598/734/9/1745987349.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Heinerscheid"
+    ],
     "name:bel_x_preferred":[
         "\u0425\u0435\u043d\u0435\u0440\u0448\u044d\u0439\u0434"
     ],
@@ -38,6 +41,9 @@
     ],
     "name:eng_x_preferred":[
         "Heinerscheid"
+    ],
+    "name:fas_x_preferred":[
+        "\u0647\u06cc\u0646\u0631\u0633\u0686\u06cc\u062f"
     ],
     "name:fra_x_preferred":[
         "Heinerscheid"
@@ -84,6 +90,9 @@
     "name:swe_x_preferred":[
         "Heinerscheid"
     ],
+    "name:tur_x_preferred":[
+        "Heinerscheid"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u0430\u0439\u043d\u0435\u0440\u0448\u0430\u0439\u0434"
     ],
@@ -115,11 +124,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977451,
         102191581,
         1125411213,
         85633275,
-        101811723
+        101811723,
+        1745977451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -152,7 +161,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733432,
+    "wof:lastmodified":1690938721,
     "wof:name":"Heinerscheid",
     "wof:parent_id":101811723,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/735/9/1745987359.geojson
+++ b/data/174/598/735/9/1745987359.geojson
@@ -21,6 +21,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Eschdorf"
+    ],
     "name:cat_x_preferred":[
         "Eschdorf"
     ],
@@ -76,11 +79,11 @@
     "woe:name_adm1":"Diekirch",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125333105,
         85633275,
-        1125776761
+        1125776761,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +116,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733437,
+    "wof:lastmodified":1690938724,
     "wof:name":"Eschdorf",
     "wof:parent_id":1125776761,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/736/5/1745987365.geojson
+++ b/data/174/598/736/5/1745987365.geojson
@@ -39,6 +39,9 @@
     "name:ltz_x_preferred":[
         "Merscheet"
     ],
+    "name:ltz_x_variant":[
+        "M\u00ebtscheed"
+    ],
     "name:msa_x_preferred":[
         "Merscheid"
     ],
@@ -46,6 +49,9 @@
         "Merscheid"
     ],
     "name:pol_x_preferred":[
+        "Merscheid"
+    ],
+    "name:por_x_preferred":[
         "Merscheid"
     ],
     "name:swe_x_preferred":[
@@ -66,11 +72,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977449,
         102191581,
         1125410761,
         85633275,
-        1745984185
+        1745984185,
+        1745977449
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +108,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733440,
+    "wof:lastmodified":1690938700,
     "wof:name":"Merscheid-l\u00e8s-Putscheid",
     "wof:parent_id":1745984185,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/738/1/1745987381.geojson
+++ b/data/174/598/738/1/1745987381.geojson
@@ -24,6 +24,9 @@
     "name:cat_x_preferred":[
         "Grass"
     ],
+    "name:deu_x_preferred":[
+        "Grass"
+    ],
     "name:eng_x_preferred":[
         "Grass"
     ],
@@ -54,11 +57,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977433,
         102191581,
         1125346159,
         85633275,
-        1125777823
+        1125777823,
+        1745977433
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -90,7 +93,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733448,
+    "wof:lastmodified":1690938701,
     "wof:name":"Grass",
     "wof:parent_id":1125777823,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/738/9/1745987389.geojson
+++ b/data/174/598/738/9/1745987389.geojson
@@ -36,6 +36,9 @@
     "name:ltz_x_preferred":[
         "Eesebur"
     ],
+    "name:ltz_x_variant":[
+        "Eesebuer"
+    ],
     "name:msa_x_preferred":[
         "Eisenborn"
     ],
@@ -74,11 +77,11 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125296455,
         85633275,
-        101812889
+        101812889,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,7 +114,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733453,
+    "wof:lastmodified":1690938701,
     "wof:name":"Eisenborn",
     "wof:parent_id":101812889,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/740/1/1745987401.geojson
+++ b/data/174/598/740/1/1745987401.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Marienthal"
     ],
+    "name:ces_x_preferred":[
+        "Marienthal"
+    ],
     "name:deu_x_preferred":[
         "Marienthal"
     ],
@@ -38,6 +41,9 @@
     ],
     "name:ltz_x_preferred":[
         "Mariendall"
+    ],
+    "name:ltz_x_variant":[
+        "M\u00e4rjendall"
     ],
     "name:msa_x_preferred":[
         "Marienthal"
@@ -66,11 +72,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1745980845,
         85633275,
-        1745984177
+        1745984177,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +108,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733459,
+    "wof:lastmodified":1690938717,
     "wof:name":"Marienthal",
     "wof:parent_id":1745984177,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/740/5/1745987405.geojson
+++ b/data/174/598/740/5/1745987405.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Ernster"
+    ],
     "name:cat_x_preferred":[
         "Ernster"
     ],
     "name:ceb_x_preferred":[
+        "Ernster"
+    ],
+    "name:deu_x_preferred":[
         "Ernster"
     ],
     "name:eng_x_preferred":[
@@ -69,11 +75,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125410759,
         85633275,
-        101753075
+        101753075,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +112,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733461,
+    "wof:lastmodified":1690938717,
     "wof:name":"Ernster",
     "wof:parent_id":101753075,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/741/7/1745987417.geojson
+++ b/data/174/598/741/7/1745987417.geojson
@@ -27,6 +27,9 @@
     "name:ceb_x_preferred":[
         "Kaundorf"
     ],
+    "name:deu_x_preferred":[
+        "Kaundorf"
+    ],
     "name:eng_x_preferred":[
         "Kaundorf"
     ],
@@ -63,11 +66,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977429,
         102191581,
         1125283425,
         85633275,
-        1126028027
+        1126028027,
+        1745977429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,7 +102,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733467,
+    "wof:lastmodified":1690938720,
     "wof:name":"Kaundorf",
     "wof:parent_id":1126028027,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/741/9/1745987419.geojson
+++ b/data/174/598/741/9/1745987419.geojson
@@ -36,6 +36,9 @@
     "name:ltz_x_preferred":[
         "Eschent"
     ],
+    "name:ltz_x_variant":[
+        "\u00c9ischt"
+    ],
     "name:msa_x_preferred":[
         "Eschette"
     ],
@@ -57,11 +60,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977431,
         102191581,
         1125410765,
         85633275,
-        101812867
+        101812867,
+        1745977431
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -93,7 +96,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733468,
+    "wof:lastmodified":1690938720,
     "wof:name":"Eschette",
     "wof:parent_id":101812867,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/742/1/1745987421.geojson
+++ b/data/174/598/742/1/1745987421.geojson
@@ -36,6 +36,9 @@
     "name:ltz_x_preferred":[
         "Bur"
     ],
+    "name:ltz_x_variant":[
+        "Buer"
+    ],
     "name:nld_x_preferred":[
         "Bour"
     ],
@@ -65,11 +68,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977439,
         102191581,
         1745980845,
         85633275,
-        1745984177
+        1745984177,
+        1745977439
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -102,7 +105,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733469,
+    "wof:lastmodified":1690938740,
     "wof:name":"Bour",
     "wof:parent_id":1745984177,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/743/1/1745987431.geojson
+++ b/data/174/598/743/1/1745987431.geojson
@@ -21,10 +21,19 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Berg"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u0435\u0440\u0433"
     ],
     "name:cat_x_preferred":[
+        "Berg"
+    ],
+    "name:ces_x_preferred":[
+        "Berg"
+    ],
+    "name:deu_x_preferred":[
         "Berg"
     ],
     "name:eng_x_preferred":[
@@ -45,6 +54,9 @@
     "name:nld_x_preferred":[
         "Berg"
     ],
+    "name:swe_x_preferred":[
+        "Berg"
+    ],
     "qs_pg:aaroncc":"LU",
     "qs_pg:gn_country":"LU",
     "qs_pg:gn_fcode":"PPL",
@@ -60,11 +72,11 @@
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "wof:belongsto":[
-        1745977447,
         102191581,
         1125325873,
         85633275,
-        101854569
+        101854569,
+        1745977447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -96,7 +108,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733474,
+    "wof:lastmodified":1690938736,
     "wof:name":"Berg-sur-Syre",
     "wof:parent_id":101854569,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/743/7/1745987437.geojson
+++ b/data/174/598/743/7/1745987437.geojson
@@ -33,13 +33,25 @@
     "name:fra_x_preferred":[
         "Grund"
     ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05e8\u05d5\u05e0\u05d3"
+    ],
     "name:ita_x_preferred":[
         "Grund"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b0\u30eb\u30f3\u30c8"
     ],
     "name:ltz_x_preferred":[
         "Gronn"
     ],
     "name:nld_x_preferred":[
+        "Grund"
+    ],
+    "name:spa_x_preferred":[
+        "Grund"
+    ],
+    "name:swe_x_preferred":[
         "Grund"
     ],
     "qs_pg:aaroncc":"LU",
@@ -69,11 +81,11 @@
     "woe:name_adm1":"Luxembourg",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +118,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733477,
+    "wof:lastmodified":1690938735,
     "wof:name":"Grund",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/174/598/744/1/1745987441.geojson
+++ b/data/174/598/744/1/1745987441.geojson
@@ -21,10 +21,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Machtum"
+    ],
     "name:cat_x_preferred":[
         "Machtum"
     ],
     "name:ceb_x_preferred":[
+        "Machtum"
+    ],
+    "name:deu_x_preferred":[
         "Machtum"
     ],
     "name:eng_x_preferred":[
@@ -76,12 +82,12 @@
     "woe:name_adm1":"Grevenmacher",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85682491,
         102191581,
         1125311551,
         85633111,
         101813323,
-        102063545
+        102063545,
+        85682491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,7 +121,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733480,
+    "wof:lastmodified":1690938735,
     "wof:name":"Machtum",
     "wof:parent_id":101813323,
     "wof:placetype":"neighbourhood",

--- a/data/856/332/75/85633275.geojson
+++ b/data/856/332/75/85633275.geojson
@@ -41,6 +41,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u041b\u0438\u0443\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
+    ],
     "name:ace_x_preferred":[
         "Luks\u00e8mburg"
     ],
@@ -50,14 +53,23 @@
     "name:aka_x_preferred":[
         "Laksemb\u025bg"
     ],
+    "name:aka_x_variant":[
+        "Luxembourg"
+    ],
     "name:als_x_preferred":[
         "Luxemburg"
     ],
     "name:amh_x_preferred":[
         "\u1209\u12ad\u1230\u121d\u1260\u122d\u130d"
     ],
+    "name:ami_x_preferred":[
+        "Luxembourg"
+    ],
     "name:ang_x_preferred":[
         "Letseburg"
+    ],
+    "name:anp_x_preferred":[
+        "\u0932\u0915\u094d\u0938\u092e\u092c\u0930\u094d\u0917"
     ],
     "name:ara_x_preferred":[
         "\u0644\u0648\u0643\u0633\u0645\u0628\u0648\u0631\u063a"
@@ -72,14 +84,26 @@
     "name:arg_x_preferred":[
         "Luxemburgo"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0648\u0643\u0633\u0645\u0628\u0648\u0631\u06ad"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u0648\u0643\u0633\u064a\u0645\u0628\u0648\u0631\u062c"
+    ],
+    "name:asm_x_preferred":[
+        "\u09b2\u09be\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09be\u09f0\u09cd\u0997"
     ],
     "name:ast_x_preferred":[
         "Luxemburgu"
     ],
     "name:ava_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
+    ],
+    "name:avk_x_preferred":[
+        "Luxemburga"
+    ],
+    "name:awa_x_preferred":[
+        "\u0932\u0915\u094d\u0938\u0947\u092e\u094d\u092c\u0930\u094d\u0917"
     ],
     "name:azb_x_preferred":[
         "\u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u0642"
@@ -92,6 +116,9 @@
     ],
     "name:bam_x_preferred":[
         "Likisanburu"
+    ],
+    "name:ban_x_preferred":[
+        "Luksemburg"
     ],
     "name:bar_x_preferred":[
         "Luxnbuag"
@@ -112,7 +139,8 @@
         "\u09b2\u09c1\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09c1\u09b0\u09cd\u0997"
     ],
     "name:ben_x_variant":[
-        "\u09b2\u09be\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09be\u09b0\u09cd\u0997"
+        "\u09b2\u09be\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09be\u09b0\u09cd\u0997",
+        "\u09b2\u09c1\u0995\u09cd\u09b8\u09c7\u09ae\u09ac\u09be\u09b0\u09cd\u0997"
     ],
     "name:bgn_x_preferred":[
         "\u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u06af"
@@ -122,6 +150,12 @@
     ],
     "name:bis_x_preferred":[
         "Luxembourg"
+    ],
+    "name:bis_x_variant":[
+        "Laksembog"
+    ],
+    "name:blk_x_preferred":[
+        "\u101c\u1030\u101e\u102d\u1009\u103a\u1017\u1010\u103a\u1001\u1019\u103a\u1038\u1011\u102e"
     ],
     "name:bod_x_preferred":[
         "\u0f63\u0f74\u0f0b\u0f66\u0f7a\u0f58\u0f0b\u0f56\u0f60\u0f74\u0f62\u0f42 (\u0f62\u0f92\u0fb1\u0f63\u0f0b\u0f41\u0f56\u0f0d)"
@@ -201,6 +235,9 @@
     ],
     "name:cze_x_variant":[
         "Lucembursko"
+    ],
+    "name:dag_x_preferred":[
+        "Luxembourg"
     ],
     "name:dan_x_colloquial":[
         "Storhertugdommet Luxemburg"
@@ -327,6 +364,9 @@
     "name:gag_x_preferred":[
         "L\u00fcksemburg"
     ],
+    "name:gcr_x_preferred":[
+        "Liksanbour"
+    ],
     "name:gla_x_preferred":[
         "Lucsamburg"
     ],
@@ -344,6 +384,12 @@
     ],
     "name:gom_x_preferred":[
         "\u0932\u0915\u094d\u0938\u0902\u092c\u0949\u0930\u094d\u0917"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf3b\ud800\udf34\ud800\udf39\ud800\udf44\ud800\udf39\ud800\udf3b\ud800\udf30\ud800\udf31\ud800\udf30\ud800\udf3f\ud800\udf42\ud800\udf32\ud800\udf43"
+    ],
+    "name:gpe_x_preferred":[
+        "Luxembourg"
     ],
     "name:grn_x_preferred":[
         "Luxemburgo"
@@ -401,6 +447,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053c\u0575\u0578\u0582\u0584\u057d\u0565\u0574\u0562\u0578\u0582\u0580\u0563"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053c\u056b\u0582\u0584\u057d\u0561\u0574\u057a\u0578\u0582\u0580\u056f"
     ],
     "name:ibo_x_preferred":[
         "Luxembourg"
@@ -484,6 +533,9 @@
     "name:khm_x_preferred":[
         "\u179b\u17bb\u1785\u17a0\u17d2\u179f\u17c6\u1794\u17bd\u179a"
     ],
+    "name:khm_x_variant":[
+        "\u179b\u17bb\u1785\u17a0\u17d2\u179f\u17c6\u1794\u17ca\u17bd\u179a"
+    ],
     "name:kik_x_preferred":[
         "Lasembagi"
     ],
@@ -541,6 +593,9 @@
     "name:lij_x_preferred":[
         "Luxemburgo"
     ],
+    "name:lij_x_variant":[
+        "Lusenb\u00f9rgo"
+    ],
     "name:lim_x_preferred":[
         "Luxemb\u00f6rg (land)"
     ],
@@ -559,6 +614,9 @@
     ],
     "name:liv_x_preferred":[
         "Luksemburg"
+    ],
+    "name:lld_x_preferred":[
+        "Luxemburg"
     ],
     "name:lmo_x_preferred":[
         "L\u00fcssemburgh"
@@ -585,6 +643,9 @@
     "name:lzh_x_preferred":[
         "\u76e7\u68ee\u5821"
     ],
+    "name:mad_x_preferred":[
+        "Luxemburg"
+    ],
     "name:mal_x_preferred":[
         "\u0d32\u0d15\u0d4d\u0d38\u0d02\u0d2c\u0d7c\u0d17\u0d4d"
     ],
@@ -600,6 +661,9 @@
     "name:mhr_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
     ],
+    "name:min_x_preferred":[
+        "Luksemburg"
+    ],
     "name:mkd_x_preferred":[
         "\u041b\u0443\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
     ],
@@ -611,6 +675,9 @@
     ],
     "name:mlt_x_preferred":[
         "Lussemburgu"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc2\uabdb\uabd6\uabe6\uabdd\uabd5\uabe7\uabd4\uabd2"
     ],
     "name:mon_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
@@ -641,6 +708,9 @@
     ],
     "name:nan_x_preferred":[
         "Luxembourg"
+    ],
+    "name:nap_x_preferred":[
+        "Lussemburgo"
     ],
     "name:nau_x_preferred":[
         "Ruketemburg"
@@ -807,6 +877,9 @@
     "name:san_x_preferred":[
         "\u0932\u0915\u094d\u0938\u092e\u094d\u092c\u0930\u094d\u0917"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5e\u1c69\u1c60\u1c65\u1c6e\u1c62\u1c75\u1c5f\u1c68\u1c5c\u1c7d"
+    ],
     "name:scn_x_preferred":[
         "Lussimburgu"
     ],
@@ -815,6 +888,12 @@
     ],
     "name:sgs_x_preferred":[
         "Lioksemb\u014drgs"
+    ],
+    "name:shi_x_preferred":[
+        "Luksmburg"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101c\u1062\u1075\u103a\u1088\u1078\u102d\u1019\u103a\u1087\u1015\u1062\u1075\u103a\u1088"
     ],
     "name:sin_x_preferred":[
         "\u0dbd\u0d9a\u0dca\u0dc3\u0db8\u0dca\u0db6\u0dbb\u0dca\u0d9c\u0dba"
@@ -836,6 +915,15 @@
     ],
     "name:sme_x_variant":[
         "Luxembourg"
+    ],
+    "name:smn_x_preferred":[
+        "Luxemburg"
+    ],
+    "name:smo_x_preferred":[
+        "Luxembourg"
+    ],
+    "name:sms_x_preferred":[
+        "Luxemburgg"
     ],
     "name:sna_x_preferred":[
         "Luxembourg"
@@ -888,6 +976,9 @@
     "name:szl_x_preferred":[
         "Luksymburg"
     ],
+    "name:szy_x_preferred":[
+        "Luxembourg"
+    ],
     "name:tam_x_preferred":[
         "\u0bb2\u0b95\u0bcd\u0b9a\u0bae\u0bcd\u0baa\u0bb0\u0bcd\u0b95\u0bcd"
     ],
@@ -899,6 +990,9 @@
     ],
     "name:tat_x_variant":[
         "\u041b\u04af\u043a\u0441\u0438\u043c\u0431\u0443\u0440"
+    ],
+    "name:tay_x_preferred":[
+        "Luxembourg"
     ],
     "name:tel_x_preferred":[
         "\u0c32\u0c15\u0c4d\u0c38\u0c02\u0c2c\u0c30\u0c4d\u0c17\u0c4d"
@@ -924,8 +1018,20 @@
     "name:tir_x_preferred":[
         "\u1209\u12ad\u1230\u121d\u1260\u122d\u130d"
     ],
+    "name:tok_x_preferred":[
+        "ma Lusepu"
+    ],
     "name:ton_x_preferred":[
         "Lakisimipeki"
+    ],
+    "name:ton_x_variant":[
+        "Lakisemipeki"
+    ],
+    "name:tpi_x_preferred":[
+        "Laksembog"
+    ],
+    "name:trv_x_preferred":[
+        "Luxembourg"
     ],
     "name:tso_x_preferred":[
         "Luxembourg"
@@ -938,6 +1044,9 @@
     ],
     "name:tur_x_preferred":[
         "L\u00fcksemburg"
+    ],
+    "name:twi_x_preferred":[
+        "Luxembourg"
     ],
     "name:udm_x_preferred":[
         "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"
@@ -1254,7 +1363,7 @@
         "naturalearth",
         "naturalearth-display-terrestrial-zoom6"
     ],
-    "wof:geomhash":"3968326817524da16a66a9d40ff30fb8",
+    "wof:geomhash":"f2935cacca93e44d7ba871f790107fa9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1272,7 +1381,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1690938692,
     "wof:name":"Luxembourg",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/858/020/39/85802039.geojson
+++ b/data/858/020/39/85802039.geojson
@@ -25,6 +25,9 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":15.0,
     "mz:tier_locality":1,
+    "name:ast_x_preferred":[
+        "Alzingen"
+    ],
     "name:cat_x_preferred":[
         "Alzingen"
     ],
@@ -95,11 +98,11 @@
     "wd:longitude":6.166667,
     "wd:wordcount":59,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125305925,
         85633275,
-        1125957373
+        1125957373,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -138,7 +141,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733535,
+    "wof:lastmodified":1690938694,
     "wof:name":"Alzingen",
     "wof:parent_id":1125957373,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/43/85802043.geojson
+++ b/data/858/020/43/85802043.geojson
@@ -57,6 +57,9 @@
     "name:por_x_preferred":[
         "Beggen"
     ],
+    "name:spa_x_preferred":[
+        "Beggen"
+    ],
     "name:swe_x_preferred":[
         "Beggen"
     ],
@@ -93,11 +96,11 @@
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":86,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125355305,
         85633275,
-        101753071
+        101753071,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -137,7 +140,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733536,
+    "wof:lastmodified":1690938694,
     "wof:name":"Beggen",
     "wof:parent_id":101753071,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/47/85802047.geojson
+++ b/data/858/020/47/85802047.geojson
@@ -61,10 +61,19 @@
     "name:ltz_x_variant":[
         "Bonnevoie"
     ],
+    "name:nld_x_preferred":[
+        "Bonnevoie"
+    ],
     "name:pol_x_preferred":[
         "Bonnevoie"
     ],
+    "name:por_x_preferred":[
+        "Bonnevoie"
+    ],
     "name:slv_x_preferred":[
+        "Bonnevoie"
+    ],
+    "name:swe_x_preferred":[
         "Bonnevoie"
     ],
     "name:tat_x_preferred":[
@@ -106,11 +115,11 @@
     "wd:longitude":6.139444,
     "wd:wordcount":114,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -151,7 +160,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733563,
+    "wof:lastmodified":1690938695,
     "wof:name":"Bonnevoie",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/53/85802053.geojson
+++ b/data/858/020/53/85802053.geojson
@@ -64,6 +64,9 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30f3\u30c4"
+    ],
     "name:kor_x_preferred":[
         "\uc13c\ud2b8"
     ],
@@ -145,11 +148,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":152,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -186,7 +189,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733564,
+    "wof:lastmodified":1690938694,
     "wof:name":"Cents",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/57/85802057.geojson
+++ b/data/858/020/57/85802057.geojson
@@ -31,6 +31,9 @@
     "name:ceb_x_preferred":[
         "Cessange"
     ],
+    "name:dan_x_preferred":[
+        "Cessange"
+    ],
     "name:deu_x_preferred":[
         "Zessingen"
     ],
@@ -43,10 +46,16 @@
     "name:ita_x_preferred":[
         "Cessange"
     ],
+    "name:jpn_x_preferred":[
+        "\u30c4\u30a7\u30a4\u30bb\u30f3\u30b0"
+    ],
     "name:ltz_x_preferred":[
         "Z\u00e9isseng"
     ],
     "name:nld_x_preferred":[
+        "Cessange"
+    ],
+    "name:spa_x_preferred":[
         "Cessange"
     ],
     "name:swe_x_preferred":[
@@ -89,11 +98,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":151,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -134,7 +143,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733565,
+    "wof:lastmodified":1690938693,
     "wof:name":"Cessange",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/61/85802061.geojson
+++ b/data/858/020/61/85802061.geojson
@@ -49,6 +49,9 @@
     "name:nld_x_preferred":[
         "Clausen"
     ],
+    "name:spa_x_preferred":[
+        "Clausen"
+    ],
     "name:swe_x_preferred":[
         "Clausen"
     ],
@@ -86,11 +89,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":264,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -131,7 +134,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733566,
+    "wof:lastmodified":1690938693,
     "wof:name":"Clausen",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/65/85802065.geojson
+++ b/data/858/020/65/85802065.geojson
@@ -55,8 +55,17 @@
     "name:nld_x_preferred":[
         "Dommeldange"
     ],
+    "name:pol_x_preferred":[
+        "Dommeldingen"
+    ],
+    "name:spa_x_preferred":[
+        "Dommeldange"
+    ],
     "name:swe_x_preferred":[
         "Dommeldange"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0414\u043e\u043c\u043c\u0435\u043b\u044c\u0434\u0430\u043d\u0436"
     ],
     "qs:gn_adm0_cc":"LU",
     "qs:gn_fcode":"PPL",
@@ -92,11 +101,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":45,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -137,7 +146,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733567,
+    "wof:lastmodified":1690938694,
     "wof:name":"Dommeldange",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/73/85802073.geojson
+++ b/data/858/020/73/85802073.geojson
@@ -34,6 +34,9 @@
     "name:deu_x_preferred":[
         "Gasperich"
     ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03ac\u03c3\u03c0\u03b5\u03c1\u03b9\u03c7"
+    ],
     "name:eng_x_preferred":[
         "Gasperich"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:swe_x_preferred":[
         "Gasperich"
+    ],
+    "name:zho_x_preferred":[
+        "\u52a0\u65af\u4f69\u91cc\u5e0c"
     ],
     "qs:gn_adm0_cc":"LU",
     "qs:gn_fcode":"PPL",
@@ -92,11 +98,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":42,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -137,7 +143,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733569,
+    "wof:lastmodified":1690938693,
     "wof:name":"Gasperich",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/77/85802077.geojson
+++ b/data/858/020/77/85802077.geojson
@@ -55,6 +55,12 @@
     "name:nld_x_preferred":[
         "Hamm"
     ],
+    "name:pol_x_preferred":[
+        "Hamm"
+    ],
+    "name:spa_x_preferred":[
+        "Hamm"
+    ],
     "name:swe_x_preferred":[
         "Hamm"
     ],
@@ -92,11 +98,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":136,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -137,7 +143,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733570,
+    "wof:lastmodified":1690938695,
     "wof:name":"Hamm",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/81/85802081.geojson
+++ b/data/858/020/81/85802081.geojson
@@ -27,6 +27,9 @@
     "name:cat_x_preferred":[
         "Howald"
     ],
+    "name:dan_x_preferred":[
+        "Howald"
+    ],
     "name:deu_x_preferred":[
         "Howald"
     ],
@@ -83,11 +86,11 @@
     "wd:longitude":6.141389,
     "wd:wordcount":333,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125305925,
         85633275,
-        1125957373
+        1125957373,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -126,7 +129,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733538,
+    "wof:lastmodified":1690938694,
     "wof:name":"Howald",
     "wof:parent_id":1125957373,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/87/85802087.geojson
+++ b/data/858/020/87/85802087.geojson
@@ -25,10 +25,16 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
     "mz:tier_locality":1,
+    "name:ast_x_preferred":[
+        "Itzig"
+    ],
     "name:cat_x_preferred":[
         "Itzig"
     ],
     "name:ceb_x_preferred":[
+        "Itzig"
+    ],
+    "name:deu_x_preferred":[
         "Itzig"
     ],
     "name:eng_x_preferred":[
@@ -86,11 +92,11 @@
     "wd:longitude":6.166667,
     "wd:wordcount":42,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125305925,
         85633275,
-        1125957373
+        1125957373,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,7 +135,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733539,
+    "wof:lastmodified":1690938693,
     "wof:name":"Itzig",
     "wof:parent_id":1125957373,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/93/85802093.geojson
+++ b/data/858/020/93/85802093.geojson
@@ -56,6 +56,9 @@
     "name:ita_x_preferred":[
         "Kirchberg"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ad\u30eb\u30b7\u30e5\u30d9\u30eb\u30b0"
+    ],
     "name:ltz_x_preferred":[
         "Kierchbierg"
     ],
@@ -63,6 +66,9 @@
         "Kirchberg"
     ],
     "name:nld_x_preferred":[
+        "Kirchberg"
+    ],
+    "name:nob_x_preferred":[
         "Kirchberg"
     ],
     "name:ron_x_preferred":[
@@ -76,6 +82,12 @@
     ],
     "name:swe_x_preferred":[
         "Kirchberg"
+    ],
+    "name:yue_x_preferred":[
+        "\u57fa\u5e0c\u8c9d\u683c"
+    ],
+    "name:zho_x_preferred":[
+        "\u57fa\u5e0c\u8d1d\u683c"
     ],
     "qs:gn_adm0_cc":"LU",
     "qs:gn_fcode":"PPL",
@@ -114,11 +126,11 @@
     "wd:longitude":6.145556,
     "wd:wordcount":440,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -159,7 +171,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733572,
+    "wof:lastmodified":1690938693,
     "wof:name":"Kirchberg",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/020/97/85802097.geojson
+++ b/data/858/020/97/85802097.geojson
@@ -46,10 +46,16 @@
     "name:ita_x_preferred":[
         "Merl"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e1\u30eb\u30eb"
+    ],
     "name:ltz_x_preferred":[
         "M\u00e4rel"
     ],
     "name:nld_x_preferred":[
+        "Merl"
+    ],
+    "name:spa_x_preferred":[
         "Merl"
     ],
     "name:swe_x_preferred":[
@@ -90,11 +96,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":42,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,7 +141,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733573,
+    "wof:lastmodified":1690938695,
     "wof:name":"Merl",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/01/85802101.geojson
+++ b/data/858/021/01/85802101.geojson
@@ -51,6 +51,9 @@
     "name:nld_x_preferred":[
         "Weimerskirch"
     ],
+    "name:spa_x_preferred":[
+        "Weimerskirch"
+    ],
     "name:swe_x_preferred":[
         "Weimerskirch"
     ],
@@ -89,11 +92,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -134,7 +137,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733574,
+    "wof:lastmodified":1690938696,
     "wof:name":"Neimersk",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/07/85802107.geojson
+++ b/data/858/021/07/85802107.geojson
@@ -37,12 +37,19 @@
     "name:eng_x_preferred":[
         "Rollingergrund"
     ],
+    "name:fra_x_preferred":[
+        "Rollingergrund"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ed\u30e9\u30f3\u30b8\u30a7\u30eb\u30b0\u30e9\u30f3"
+    ],
     "name:ltz_x_preferred":[
         "Gemeng Rollengergronn"
     ],
     "name:ltz_x_variant":[
         "Rollingergrund",
-        "Rollengergronn-Belair-Nord"
+        "Rollengergronn-Belair-Nord",
+        "Rollengergronn"
     ],
     "name:nld_x_preferred":[
         "Rollingergrund"
@@ -81,11 +88,11 @@
     "src:lbl_centroid":"whosonfirst",
     "wd:wordcount":139,
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -126,7 +133,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733576,
+    "wof:lastmodified":1690938695,
     "wof:name":"Rollingergrund",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/13/85802113.geojson
+++ b/data/858/021/13/85802113.geojson
@@ -52,6 +52,9 @@
     "name:nld_x_preferred":[
         "Weimerskirch"
     ],
+    "name:spa_x_preferred":[
+        "Weimerskirch"
+    ],
     "name:swe_x_preferred":[
         "Weimerskirch"
     ],
@@ -91,11 +94,11 @@
     ],
     "src:lbl_centroid":"whosonfirst",
     "wof:belongsto":[
-        1745977427,
         102191581,
         1125286201,
         85633275,
-        101751765
+        101751765,
+        1745977427
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -136,7 +139,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1626733577,
+    "wof:lastmodified":1690938696,
     "wof:name":"Waymersk",
     "wof:parent_id":101751765,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.