### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/112/531/155/1/1125311551.geojson
+++ b/data/112/531/155/1/1125311551.geojson
@@ -25,10 +25,12 @@
     "gn:fcode":"ADM3",
     "gn:population":0,
     "iso:country":"LU",
-    "lbl:latitude":49.60833,
-    "lbl:longitude":6.40583,
+    "lbl:latitude":49.611965,
+    "lbl:longitude":6.393956,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
+    "mps:latitude":49.611965,
+    "mps:longitude":6.393956,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
@@ -123,7 +125,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"eurostat",
     "src:population_date":"2020",
     "woe:adm0_id":23424881,
@@ -149,7 +151,7 @@
     "wof:geom_alt":[
         "qs_pg"
     ],
-    "wof:geomhash":"d9cfecb610b420dea71c1ac79a0a4275",
+    "wof:geomhash":"844f17f3b8fbe50352571ff7bee6db7b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -170,7 +172,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1684353995,
+    "wof:lastmodified":1694320497,
     "wof:name":"Wormeldange",
     "wof:parent_id":102063545,
     "wof:placetype":"localadmin",

--- a/data/112/532/140/1/1125321401.geojson
+++ b/data/112/532/140/1/1125321401.geojson
@@ -23,10 +23,12 @@
     "geom:longitude":6.012194,
     "gn:country":null,
     "iso:country":"LU",
-    "lbl:latitude":49.465732,
-    "lbl:longitude":6.042003,
+    "lbl:latitude":49.463429,
+    "lbl:longitude":6.007299,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
+    "mps:latitude":49.463429,
+    "mps:longitude":6.007299,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
@@ -139,7 +141,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"eurostat",
     "src:population_date":"2020",
     "woe:adm0_id":23424881,
@@ -163,7 +165,7 @@
     "wof:geom_alt":[
         "qs_pg"
     ],
-    "wof:geomhash":"7a339efbf2ff84670e1b1133ea81b4f6",
+    "wof:geomhash":"aa1c540bd9e86907c123ac9f9a1fa8e8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -183,7 +185,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1684353996,
+    "wof:lastmodified":1694320497,
     "wof:name":"Rumelange",
     "wof:parent_id":1745977435,
     "wof:placetype":"localadmin",

--- a/data/112/539/065/9/1125390659.geojson
+++ b/data/112/539/065/9/1125390659.geojson
@@ -25,10 +25,12 @@
     "gn:fcode":"ADM3",
     "gn:population":0,
     "iso:country":"LU",
-    "lbl:latitude":49.91667,
-    "lbl:longitude":6.13333,
+    "lbl:latitude":49.873178,
+    "lbl:longitude":6.148029,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
+    "mps:latitude":49.873178,
+    "mps:longitude":6.148029,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
@@ -204,7 +206,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"eurostat",
     "src:population_date":"2020",
     "woe:adm0_id":23424881,
@@ -229,7 +231,7 @@
     "wof:geom_alt":[
         "qs_pg"
     ],
-    "wof:geomhash":"bb6b50fa0545e33402fdfc32fe2c4237",
+    "wof:geomhash":"e64f12f48d3a4aec4f5430bce5e61f0a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -249,7 +251,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1684353996,
+    "wof:lastmodified":1694320497,
     "wof:name":"Diekirch",
     "wof:parent_id":1745977449,
     "wof:placetype":"localadmin",

--- a/data/112/539/066/7/1125390667.geojson
+++ b/data/112/539/066/7/1125390667.geojson
@@ -25,10 +25,12 @@
     "gn:fcode":"ADM3",
     "gn:population":0,
     "iso:country":"LU",
-    "lbl:latitude":49.91667,
-    "lbl:longitude":5.91667,
+    "lbl:latitude":49.98912,
+    "lbl:longitude":5.942259,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
+    "mps:latitude":49.98912,
+    "mps:longitude":5.942259,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
@@ -200,7 +202,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"eurostat",
     "src:population_date":"2020",
     "woe:adm0_id":23424881,
@@ -225,7 +227,7 @@
     "wof:geom_alt":[
         "qs_pg"
     ],
-    "wof:geomhash":"2f8b400a683158d61271cb246c2eda71",
+    "wof:geomhash":"698f38babc7f1317ac8ab2a18d616639",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -245,7 +247,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1684353996,
+    "wof:lastmodified":1694320498,
     "wof:name":"Wiltz",
     "wof:parent_id":1745977429,
     "wof:placetype":"localadmin",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.