### PR TITLE
lu concordances, placetype local, and more

### DIFF
--- a/data/174/597/742/7/1745977427.geojson
+++ b/data/174/597/742/7/1745977427.geojson
@@ -107,6 +107,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-LU"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925179,
     "wof:geomhash":"81cd2abc030c7deb47682e7c882e7760",
@@ -128,7 +132,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1695885134,
     "wof:name":"Luxembourg",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/742/9/1745977429.geojson
+++ b/data/174/597/742/9/1745977429.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-WI"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925181,
     "wof:geomhash":"85f010e3b207ae8af1b9fe8ef32b5029",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884755,
     "wof:name":"Wiltz",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/743/1/1745977431.geojson
+++ b/data/174/597/743/1/1745977431.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-RD"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925182,
     "wof:geomhash":"1232d5223889a92fca6f2c344b17dea0",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884755,
     "wof:name":"Redange",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/743/3/1745977433.geojson
+++ b/data/174/597/743/3/1745977433.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-CA"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925183,
     "wof:geomhash":"608c11017b217c255ca6b2ae17133804",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493254,
+    "wof:lastmodified":1695884755,
     "wof:name":"Capellen",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/743/5/1745977435.geojson
+++ b/data/174/597/743/5/1745977435.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-ES"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925183,
     "wof:geomhash":"425748765f2c73db5c87a6c4024d552a",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884755,
     "wof:name":"Esch-sur-Alzette",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/743/9/1745977439.geojson
+++ b/data/174/597/743/9/1745977439.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-ME"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925184,
     "wof:geomhash":"a6813781da0981bb1121f03bfc536314",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884755,
     "wof:name":"Mersch",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/744/1/1745977441.geojson
+++ b/data/174/597/744/1/1745977441.geojson
@@ -56,6 +56,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-DI"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925185,
     "wof:geomhash":"2c543fe710fb211c9dcfa7730746297e",
@@ -77,7 +81,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493263,
+    "wof:lastmodified":1695885131,
     "wof:name":"Diekirch",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/744/3/1745977443.geojson
+++ b/data/174/597/744/3/1745977443.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-RM"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925186,
     "wof:geomhash":"9b57dab8037e52a24402151aeefb5464",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884755,
     "wof:name":"Remich",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/744/5/1745977445.geojson
+++ b/data/174/597/744/5/1745977445.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-EC"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925187,
     "wof:geomhash":"6ec91e15517f314664d10c018aa9b330",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493254,
+    "wof:lastmodified":1695884755,
     "wof:name":"Echternach",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/744/7/1745977447.geojson
+++ b/data/174/597/744/7/1745977447.geojson
@@ -65,6 +65,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-GR"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925188,
     "wof:geomhash":"4d029755b975bf991f2d55eed539d0d8",
@@ -86,7 +90,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884906,
     "wof:name":"Grevenmacher",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/744/9/1745977449.geojson
+++ b/data/174/597/744/9/1745977449.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-VD"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925188,
     "wof:geomhash":"bc8abd48985787f5ced95a57de09da4a",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884755,
     "wof:name":"Vianden",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/174/597/745/1/1745977451.geojson
+++ b/data/174/597/745/1/1745977451.geojson
@@ -35,6 +35,10 @@
         85633275
     ],
     "wof:breaches":[],
+    "wof:concordances":{
+        "iso:code":"LU-CL"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:created":1624925189,
     "wof:geomhash":"7ccca7516bfd9d4d4415c804b2dcb0ed",
@@ -56,7 +60,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694493254,
+    "wof:lastmodified":1695884755,
     "wof:name":"Clervaux",
     "wof:parent_id":85633275,
     "wof:placetype":"region",

--- a/data/856/332/75/85633275.geojson
+++ b/data/856/332/75/85633275.geojson
@@ -1347,6 +1347,7 @@
         "hasc:id":"LU",
         "icao:code":"LX",
         "ioc:id":"LUX",
+        "iso:code":"LU",
         "itu:id":"LUX",
         "m49:code":"442",
         "marc:id":"lu",
@@ -1360,6 +1361,7 @@
         "wk:page":"Luxembourg",
         "wmo:id":"BX"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LU",
     "wof:country_alpha3":"LUX",
     "wof:geom_alt":[
@@ -1384,7 +1386,7 @@
         "ltz",
         "deu"
     ],
-    "wof:lastmodified":1694492264,
+    "wof:lastmodified":1695881377,
     "wof:name":"Luxembourg",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.